### PR TITLE
Fix memory leak when ngx_mruby raise error and return 5xx status code

### DIFF
--- a/src/ngx_http_mruby_module.c
+++ b/src/ngx_http_mruby_module.c
@@ -715,6 +715,7 @@ ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state,
 {
   int result_len;
   int ai = 0;
+  int exc_ai = 0;
   mrb_value mrb_result;
   ngx_http_mruby_ctx_t *ctx;
   ngx_mrb_rputs_chain_list_t *chain;
@@ -748,10 +749,12 @@ ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state,
       , ai
     );
   }
+  exc_ai = mrb_gc_arena_save(state->mrb);
   mrb_result = mrb_run(state->mrb, code->proc, mrb_top_self(state->mrb));
   if (state->mrb->exc) {
     ngx_mrb_raise_error(state->mrb, mrb_obj_value(state->mrb->exc), r);
     r->headers_out.status = NGX_HTTP_INTERNAL_SERVER_ERROR;
+    mrb_gc_arena_restore(state->mrb, exc_ai);
   }
   else if (result != NULL) {
     if (mrb_nil_p(mrb_result)) {


### PR DESCRIPTION
## config
raise method error code
```
        location /mruby {
          mruby_content_handler_code 'Nginx.echoo "aaa"';
        }
```

## bechmark
```
ab -c 100 -n 100000 -k http://127.0.0.1:8001/mruby
```


## startup
```
matsumo+ 28223  0.0  0.0  27296  1688 ?        Ss   14:30   0:00 ./build/nginx/sbin/nginx
```
1688

## before merge
```
matsumo+  2718 49.6  2.1 203376 177316 ?       Ss   14:41   0:11 ./build/nginx/sbin/nginx
```
1688 -> 177316

## after merge
```
matsumo+ 28223 11.2  0.0  28528  3452 ?        Ss   14:30   0:11 ./build/nginx/sbin/nginx
```
1688 -> 3452

wow!