### PR TITLE
Fix memory leak when using mruby_set{,_code} directive

### DIFF
--- a/src/ngx_http_mruby_module.c
+++ b/src/ngx_http_mruby_module.c
@@ -782,6 +782,8 @@ ngx_int_t ngx_mrb_run(ngx_http_request_t *r, ngx_mrb_state_t *state,
         , __LINE__
         , mrb_str_to_cstr(state->mrb, mrb_result)
       );
+      mrb_gc_arena_restore(state->mrb, exc_ai);
+      return NGX_OK;
     }
   }
 


### PR DESCRIPTION
## config
```
        location /mruby_full_obj {
          mruby_set_code $matsu '"hogehoge"';
          mruby_content_handler_code 'r = Nginx::Request.new; Nginx.echo r.var.matsu';
        }

```

## bechmark
```
ab -c 100 -n 100000 -k http://127.0.0.1:8001/mruby_full_obj
```


## startup
```
matsumo+ 12217  0.0  0.0  27296  2164 ?        Ss   17:53   0:00 ./build/nginx/sbin/nginx
```
2164

## before merge
```
matsumo+ 19054 37.2  0.2  47176 21776 ?        Ss   18:02   0:08 ./build/nginx/sbin/nginx
```
2164 ->

## after merge
```
matsumo+ 12217 13.2  0.0  28360  3352 ?        Ss   17:53   0:08 ./build/nginx/sbin/nginx
```
2164 -> 3352

yey!