### PR TITLE
Fix expr return value is 0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,8 +22,10 @@ fi
 if [ "$NUM_THREADS_ENV" != "" ]; then
     NUM_THREADS=$NUM_THREADS_ENV
 else
-    NUM_THREADS=$(expr `getconf _NPROCESSORS_ONLN` / 2)
-    if [ $NUM_THREADS -eq "0" ]; then
+    NUM_PROCESSORS=`getconf _NPROCESSORS_ONLN`
+    if [ $NUM_PROCESSORS -gt 1 ]; then
+        NUM_THREADS=$(expr $NUM_PROCESSORS / 2)
+    else
         NUM_THREADS=1
     fi
 fi


### PR DESCRIPTION
`getconf _NPROCESSORS_ONLN` が 1 の時にビルドが失敗する問題を修正しました。

expr の結果が 0 のとき、return code が !0 になることがあります。`build.sh` では `set -e` としているため、それが異常コードと判定され実行に失敗していました。