### PR TITLE
Support controling response headers at output_filter phase

### DIFF
--- a/src/ngx_http_mruby_filter.c
+++ b/src/ngx_http_mruby_filter.c
@@ -27,9 +27,6 @@ static mrb_value ngx_mrb_set_filter_body(mrb_state *mrb, mrb_value self)
 {
   ngx_http_request_t *r = ngx_mrb_get_request();
   ngx_http_mruby_ctx_t *ctx = ngx_http_get_module_ctx(r, ngx_http_mruby_module);
-  ngx_int_t rc;
-  ngx_chain_t out;
-  ngx_buf_t *b;
   mrb_value body;
 
   mrb_get_args(mrb, "o", &body);
@@ -40,31 +37,7 @@ static mrb_value ngx_mrb_set_filter_body(mrb_state *mrb, mrb_value self)
   ctx->body = (u_char *)mrb_str_to_cstr(mrb, body);
   ctx->body_length = RSTRING_LEN(body);
 
-  b = ngx_pcalloc(r->pool, sizeof(ngx_buf_t));
-  if (b == NULL) {
-    ngx_log_error(NGX_LOG_ERR
-      , r->connection->log
-      , 0
-      , "failed to allocate memory from r->pool %s:%d"
-      , __FUNCTION__
-      , __LINE__
-    );
-    return mrb_fixnum_value(NGX_ERROR);
-  }
-  b->pos = ctx->body;
-  b->last = ctx->body + ctx->body_length;
-  b->memory = 1;
-  b->last_buf = 1;
-
-  out.buf = b;
-  out.next = NULL;
-
-  r->headers_out.content_length_n = b->last - b->pos;
-  rc = ngx_http_next_header_filter(r);
-  if (rc == NGX_ERROR || rc > NGX_OK || r->header_only) {
-    return mrb_fixnum_value(NGX_ERROR);
-  }
-  return mrb_fixnum_value(ngx_http_next_body_filter(r, &out));
+  return mrb_fixnum_value(ctx->body_length);
 }
 
 void ngx_mrb_filter_class_init(mrb_state *mrb, struct RClass *class)

--- a/src/ngx_http_mruby_module.c
+++ b/src/ngx_http_mruby_module.c
@@ -1999,6 +1999,8 @@ static ngx_int_t ngx_http_mruby_body_filter_inline_handler(
       ngx_http_mruby_module);
   ngx_http_mruby_ctx_t *ctx = ngx_http_get_module_ctx(r, ngx_http_mruby_module);
   ngx_int_t rc;
+  ngx_chain_t out;
+  ngx_buf_t *b;
 
   if((rc = ngx_http_mruby_read_body(r, in, ctx)) != NGX_OK) {
     if (rc == NGX_AGAIN) {
@@ -2016,8 +2018,38 @@ static ngx_int_t ngx_http_mruby_body_filter_inline_handler(
 
   r->connection->buffered &= ~0x08;
 
-  return ngx_mrb_run(r, mmcf->state, mlcf->body_filter_inline_code,
+  rc = ngx_mrb_run(r, mmcf->state, mlcf->body_filter_inline_code,
       mlcf->cached, NULL);
+  if (rc == NGX_ERROR) {
+    return NGX_ERROR;
+  }
+
+  b = ngx_pcalloc(r->pool, sizeof(ngx_buf_t));
+  if (b == NULL) {
+    ngx_log_error(NGX_LOG_ERR
+      , r->connection->log
+      , 0
+      , "failed to allocate memory from r->pool %s:%d"
+      , __FUNCTION__
+      , __LINE__
+    );
+    return NGX_ERROR;
+  }
+
+  b->pos = ctx->body;
+  b->last = ctx->body + ctx->body_length;
+  b->memory = 1;
+  b->last_buf = 1;
+
+  out.buf = b;
+  out.next = NULL;
+
+  r->headers_out.content_length_n = b->last - b->pos;
+  rc = ngx_http_next_header_filter(r);
+  if (rc == NGX_ERROR || rc > NGX_OK || r->header_only) {
+    return NGX_ERROR;
+  }
+  return ngx_http_next_body_filter(r, &out);
 }
 
 static ngx_int_t ngx_http_mruby_header_filter(ngx_http_request_t *r)

--- a/test.sh
+++ b/test.sh
@@ -73,7 +73,7 @@ make install
 ps -C nginx && killall nginx
 cp -p test/build_config.rb ./mruby/.
 sed -e "s|__NGXDOCROOT__|${NGINX_INSTALL_DIR}/html/|g" test/conf/nginx.conf > ${NGINX_INSTALL_DIR}/conf/nginx.conf
-cp -p test/html/* ${NGINX_INSTALL_DIR}/html/.
+cp -pr test/html/* ${NGINX_INSTALL_DIR}/html/.
 
 ${NGINX_INSTALL_DIR}/sbin/nginx &
 sleep 2

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -314,6 +314,13 @@ http {
               Nginx.rputs get_server_class.to_s
             ';
         }
+
+        # test for header at output_filter
+        location /output_filter_header {
+            mruby_output_filter_code '
+              Nginx::Request.new.headers_out["x-add-new-header"] = "new_header"
+            ';
+        }
     }
 }
 

--- a/test/html/output_filter_header/index.html
+++ b/test/html/output_filter_header/index.html
@@ -1,0 +1,1 @@
+output_filter_header

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -170,4 +170,10 @@ t.assert('ngx_mruby - get server class name', 'location /server_class') do
   t.assert_equal "Nginx", res["body"]
 end
 
+t.assert('ngx_mruby - add response header in output_filter', 'location /output_filter_header') do
+  res = HttpRequest.new.get base + '/output_filter_header/index.html'
+  t.assert_equal "output_filter_header\n", res["body"]
+  t.assert_equal "new_header", res["x-add-new-header"]
+end
+
 t.report


### PR DESCRIPTION
ngx_mruby can't control response headers at output_filter phase. So, this PR support the header control.
```nginx
location /hoge {
  mruby_output_filter_code '
    r = Nginx::Request.new
    r.headers_out["Server2"] = "matsu"
  ';
}   
```
```
$ curl  http://127.0.0.1:58080/hoge/hello.html -v
* About to connect() to 127.0.0.1 port 58080 (#0)
*   Trying 127.0.0.1... connected
* Connected to 127.0.0.1 (127.0.0.1) port 58080 (#0)
> GET /hoge/hello.html HTTP/1.1
> User-Agent: curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.16.2.3 Basic ECC zlib/1.2.3 libidn/1.18 libssh2/1.4.2
> Host: 127.0.0.1:58080
> Accept: */*
>
< HTTP/1.1 200 OK
< Server: nginx/1.7.11
< Date: Wed, 10 Jun 2015 14:05:37 GMT
< Content-Type: text/html
< Content-Length: 6
< Last-Modified: Wed, 10 Jun 2015 12:28:00 GMT
< Connection: keep-alive
< ETag: "55782d50-6"
< Server2: matsu
< Accept-Ranges: bytes
<
hello
* Connection #0 to host 127.0.0.1 left intact
* Closing connection #0
```