### PR TITLE
Add Nginx::Upstream class and method

### DIFF
--- a/config
+++ b/config
@@ -3,7 +3,7 @@
 ngx_addon_name=ngx_http_mruby_module
 mruby_root=$ngx_addon_dir/mruby
 
-HTTP_FILTER_MODULES="$HTTP_FILTER_MODULES ngx_http_mruby_module"
+HTTP_FILTER_MODULES="$HTTP_FILTER_MODULES ngx_http_mruby_module __ngx_http_upstream_keepalive_module"
 
 NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
                 $ngx_addon_dir/src/ngx_http_mruby_module.c \

--- a/config
+++ b/config
@@ -14,6 +14,7 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
                 $ngx_addon_dir/src/ngx_http_mruby_connection.c \
                 $ngx_addon_dir/src/ngx_http_mruby_server.c \
                 $ngx_addon_dir/src/ngx_http_mruby_filter.c \
+                $ngx_addon_dir/src/ngx_http_mruby_upstream.c \
                 "
 
 CORE_LIBS="$CORE_LIBS $mruby_root/build/host/mrblib/mrblib.o $mruby_root/build/host/lib/libmruby.a -lm"

--- a/src/ngx_http_mruby_core.c
+++ b/src/ngx_http_mruby_core.c
@@ -431,7 +431,7 @@ mrb_value ngx_mrb_f_global_remove(mrb_state *mrb, mrb_value self)
 
 void ngx_mrb_core_class_init(mrb_state *mrb, struct RClass *class)
 {
-  mrb_define_method(mrb, mrb->kernel_module, "server_name", ngx_mrb_server_name, ARGS_NONE());
+  mrb_define_method(mrb, mrb->kernel_module, "server_name", ngx_mrb_server_name, MRB_ARGS_NONE());
 
   mrb_define_const(mrb, class, "OK", mrb_fixnum_value(NGX_OK));
   mrb_define_const(mrb, class, "ERROR", mrb_fixnum_value(NGX_ERROR));

--- a/src/ngx_http_mruby_init.c
+++ b/src/ngx_http_mruby_init.c
@@ -12,6 +12,7 @@
 #include "ngx_http_mruby_var.h"
 #include "ngx_http_mruby_connection.h"
 #include "ngx_http_mruby_server.h"
+#include "ngx_http_mruby_upstream.h"
 
 #include <mruby.h>
 #include <mruby/compile.h>
@@ -23,6 +24,7 @@ void ngx_mrb_var_class_init(mrb_state *mrb, struct RClass *calss);
 void ngx_mrb_conn_class_init(mrb_state *mrb, struct RClass *calss);
 void ngx_mrb_server_class_init(mrb_state *mrb, struct RClass *calss);
 void ngx_mrb_filter_class_init(mrb_state *mrb, struct RClass *calss);
+void ngx_mrb_upstream_class_init(mrb_state *mrb, struct RClass *calss);
 
 
 ngx_int_t ngx_mrb_class_init(mrb_state *mrb)
@@ -37,6 +39,7 @@ ngx_int_t ngx_mrb_class_init(mrb_state *mrb)
   ngx_mrb_conn_class_init(mrb, class); GC_ARENA_RESTORE;
   ngx_mrb_server_class_init(mrb, class); GC_ARENA_RESTORE;
   ngx_mrb_filter_class_init(mrb, class); GC_ARENA_RESTORE;
+  ngx_mrb_upstream_class_init(mrb, class); GC_ARENA_RESTORE;
 
   return NGX_OK;
 }

--- a/src/ngx_http_mruby_init.c
+++ b/src/ngx_http_mruby_init.c
@@ -23,7 +23,9 @@ void ngx_mrb_var_class_init(mrb_state *mrb, struct RClass *calss);
 void ngx_mrb_conn_class_init(mrb_state *mrb, struct RClass *calss);
 void ngx_mrb_server_class_init(mrb_state *mrb, struct RClass *calss);
 void ngx_mrb_filter_class_init(mrb_state *mrb, struct RClass *calss);
+#ifdef NGX_USE_MRUBY_UPSTREAM
 void ngx_mrb_upstream_class_init(mrb_state *mrb, struct RClass *calss);
+#endif
 
 
 ngx_int_t ngx_mrb_class_init(mrb_state *mrb)
@@ -38,7 +40,9 @@ ngx_int_t ngx_mrb_class_init(mrb_state *mrb)
   ngx_mrb_conn_class_init(mrb, class); GC_ARENA_RESTORE;
   ngx_mrb_server_class_init(mrb, class); GC_ARENA_RESTORE;
   ngx_mrb_filter_class_init(mrb, class); GC_ARENA_RESTORE;
+#ifdef NGX_USE_MRUBY_UPSTREAM
   ngx_mrb_upstream_class_init(mrb, class); GC_ARENA_RESTORE;
+#endif
 
   return NGX_OK;
 }

--- a/src/ngx_http_mruby_init.c
+++ b/src/ngx_http_mruby_init.c
@@ -12,7 +12,6 @@
 #include "ngx_http_mruby_var.h"
 #include "ngx_http_mruby_connection.h"
 #include "ngx_http_mruby_server.h"
-#include "ngx_http_mruby_upstream.h"
 
 #include <mruby.h>
 #include <mruby/compile.h>

--- a/src/ngx_http_mruby_module.h
+++ b/src/ngx_http_mruby_module.h
@@ -17,6 +17,10 @@
 #define MODULE_NAME "ngx_mruby"
 #define MODULE_VERSION "1.10.12"
 
+#if (nginx_version > 1007999)
+  #define NGX_USE_MRUBY_UPSTREAM
+#endif
+
 typedef enum code_type_t {
   NGX_MRB_CODE_TYPE_FILE,
   NGX_MRB_CODE_TYPE_STRING

--- a/src/ngx_http_mruby_upstream.c
+++ b/src/ngx_http_mruby_upstream.c
@@ -53,11 +53,6 @@ static mrb_value ngx_mrb_upstream_init(mrb_state *mrb, mrb_value self)
   return self;
 }
 
-static mrb_value ngx_mrb_upstream_set_keepalive(mrb_state *mrb, mrb_value self)
-{
-  return mrb_nil_value();
-}
-
 static mrb_value ngx_mrb_upstream_set_cache(mrb_state *mrb, mrb_value self)
 {
   ngx_mruby_upstream_context *ctx = DATA_PTR(self);
@@ -93,7 +88,6 @@ void ngx_mrb_upstream_class_init(mrb_state *mrb, struct RClass *class)
 
   class_upstream = mrb_define_class_under(mrb, class, "Upstream", mrb->object_class);
   mrb_define_method(mrb, class_upstream, "initialize", ngx_mrb_upstream_init, MRB_ARGS_REQ(1));
-  mrb_define_method(mrb, class_upstream, "keepalive=", ngx_mrb_upstream_set_keepalive, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, class_upstream, "keepalive_cache", ngx_mrb_upstream_get_cache, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_upstream, "keepalive_cache=", ngx_mrb_upstream_set_cache, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, class_upstream, "hostname", ngx_mrb_upstream_get_hostname, MRB_ARGS_NONE());

--- a/src/ngx_http_mruby_upstream.c
+++ b/src/ngx_http_mruby_upstream.c
@@ -72,6 +72,15 @@ static mrb_value ngx_mrb_upstream_set_cache(mrb_state *mrb, mrb_value self)
   return mrb_fixnum_value(cache);
 }
 
+static mrb_value ngx_mrb_upstream_get_cache(mrb_state *mrb, mrb_value self)
+{
+  //ngx_mruby_upstream_context *ctx = DATA_PTR(self);
+  __ngx_http_upstream_keepalive_srv_conf_t *kcf = ngx_http_get_module_srv_conf(
+      ngx_mrb_get_request(), __ngx_http_upstream_keepalive_module);
+
+  return mrb_fixnum_value(kcf->max_cached);
+}
+
 static mrb_value ngx_mrb_upstream_get_hostname(mrb_state *mrb, mrb_value self)
 {
   ngx_mruby_upstream_context *ctx = DATA_PTR(self);
@@ -85,6 +94,7 @@ void ngx_mrb_upstream_class_init(mrb_state *mrb, struct RClass *class)
   class_upstream = mrb_define_class_under(mrb, class, "Upstream", mrb->object_class);
   mrb_define_method(mrb, class_upstream, "initialize", ngx_mrb_upstream_init, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, class_upstream, "keepalive=", ngx_mrb_upstream_set_keepalive, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, class_upstream, "keepalive_cache", ngx_mrb_upstream_get_cache, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_upstream, "keepalive_cache=", ngx_mrb_upstream_set_cache, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, class_upstream, "hostname", ngx_mrb_upstream_get_hostname, MRB_ARGS_NONE());
 }

--- a/src/ngx_http_mruby_upstream.c
+++ b/src/ngx_http_mruby_upstream.c
@@ -69,7 +69,6 @@ static mrb_value ngx_mrb_upstream_set_cache(mrb_state *mrb, mrb_value self)
 
 static mrb_value ngx_mrb_upstream_get_cache(mrb_state *mrb, mrb_value self)
 {
-  //ngx_mruby_upstream_context *ctx = DATA_PTR(self);
   __ngx_http_upstream_keepalive_srv_conf_t *kcf = ngx_http_get_module_srv_conf(
       ngx_mrb_get_request(), __ngx_http_upstream_keepalive_module);
 

--- a/src/ngx_http_mruby_upstream.c
+++ b/src/ngx_http_mruby_upstream.c
@@ -5,6 +5,7 @@
 */
 
 #include "ngx_http_mruby_upstream.h"
+#include "ngx_http_mruby_request.h"
 
 #include <mruby.h>
 #include <mruby/proc.h>
@@ -59,7 +60,16 @@ static mrb_value ngx_mrb_upstream_set_keepalive(mrb_state *mrb, mrb_value self)
 
 static mrb_value ngx_mrb_upstream_set_cache(mrb_state *mrb, mrb_value self)
 {
-  return mrb_nil_value();
+  ngx_mruby_upstream_context *ctx = DATA_PTR(self);
+  __ngx_http_upstream_keepalive_srv_conf_t *kcf = ngx_http_get_module_srv_conf(
+      ngx_mrb_get_request(), __ngx_http_upstream_keepalive_module);
+  unsigned int cache;
+
+  mrb_get_args(mrb, "i", &cache);
+  ctx->cache = cache;
+
+  kcf->max_cached = cache;
+  return mrb_fixnum_value(cache);
 }
 
 static mrb_value ngx_mrb_upstream_get_hostname(mrb_state *mrb, mrb_value self)

--- a/src/ngx_http_mruby_upstream.c
+++ b/src/ngx_http_mruby_upstream.c
@@ -61,7 +61,12 @@ static mrb_value ngx_mrb_upstream_set_cache(mrb_state *mrb, mrb_value self)
   unsigned int cache;
 
   mrb_get_args(mrb, "i", &cache);
-  ctx->cache = cache;
+
+  if (cache > 1) {
+    ctx->cache = cache;
+  } else {
+    mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid upstream_cache: set value > 1");
+  }
 
   kcf->max_cached = cache;
   return mrb_fixnum_value(cache);
@@ -71,6 +76,8 @@ static mrb_value ngx_mrb_upstream_get_cache(mrb_state *mrb, mrb_value self)
 {
   __ngx_http_upstream_keepalive_srv_conf_t *kcf = ngx_http_get_module_srv_conf(
       ngx_mrb_get_request(), __ngx_http_upstream_keepalive_module);
+
+  /* max_cached is 1 by default */
 
   return mrb_fixnum_value(kcf->max_cached);
 }

--- a/src/ngx_http_mruby_upstream.c
+++ b/src/ngx_http_mruby_upstream.c
@@ -97,7 +97,8 @@ static mrb_value ngx_mrb_upstream_set_cache(mrb_state *mrb, mrb_value self)
   ngx_mruby_upstream_context *ctx = DATA_PTR(self);
   __ngx_http_upstream_keepalive_srv_conf_t *kcf;
 
-  kcf = ngx_http_conf_upstream_srv_conf(ctx->us, __ngx_http_upstream_keepalive_module);
+  kcf = ngx_http_conf_upstream_srv_conf(ctx->us,
+      __ngx_http_upstream_keepalive_module);
 
   mrb_get_args(mrb, "i", &cache);
 
@@ -114,7 +115,8 @@ static mrb_value ngx_mrb_upstream_get_cache(mrb_state *mrb, mrb_value self)
   ngx_mruby_upstream_context *ctx = DATA_PTR(self);
   __ngx_http_upstream_keepalive_srv_conf_t *kcf;
 
-  kcf = ngx_http_conf_upstream_srv_conf(ctx->us, __ngx_http_upstream_keepalive_module);
+  kcf = ngx_http_conf_upstream_srv_conf(ctx->us,
+      __ngx_http_upstream_keepalive_module);
 
   /* max_cached is 1 by default */
 
@@ -134,32 +136,27 @@ static mrb_value ngx_mrb_upstream_set_server(mrb_state *mrb, mrb_value self)
 {
   ngx_mruby_upstream_context *ctx = DATA_PTR(self);
   ngx_url_t u;
-  mrb_value host;
+  mrb_value server;
   ngx_http_request_t *r = ngx_mrb_get_request();
 
-  mrb_get_args(mrb, "o", &host);
+  mrb_get_args(mrb, "o", &server);
 
   ngx_memzero(&u, sizeof(ngx_url_t));
-  u.url.data = (u_char *)RSTRING_PTR(host);
-  u.url.len = RSTRING_LEN(host);
+  u.url.data = (u_char *)RSTRING_PTR(server);
+  u.url.len = RSTRING_LEN(server);
   u.default_port = 80;
   if (ngx_parse_url(r->pool, &u) != NGX_OK) {
     if (u.err) {
       mrb_raisef(mrb, E_RUNTIME_ERROR, "%S in upstream %S", 
-          mrb_str_new_cstr(mrb, u.err), host);
+          mrb_str_new_cstr(mrb, u.err), server);
     }
   }
-  mrb_p(mrb, mrb_str_new(mrb, (char *)u.url.data, u.url.len));
-  mrb_p(mrb, mrb_str_new(mrb, (char *)ctx->target->name.data,
-        ctx->target->name.len));
   ctx->target->name = u.url;
   ctx->target->server = u.url;
   ctx->target->sockaddr = u.addrs[0].sockaddr;
   ctx->target->socklen = u.addrs[0].socklen;
-  mrb_p(mrb, mrb_str_new(mrb, (char *)ctx->target->name.data,
-        ctx->target->name.len));
 
-  return host;
+  return server;
 }
 
 void ngx_mrb_upstream_class_init(mrb_state *mrb, struct RClass *class)

--- a/src/ngx_http_mruby_upstream.c
+++ b/src/ngx_http_mruby_upstream.c
@@ -4,6 +4,12 @@
 // See Copyright Notice in ngx_http_mruby_module.c
 */
 
+#include "ngx_http_mruby_module.h"
+
+#ifndef NGX_USE_MRUBY_UPSTREAM
+#include "ngx_http_mruby_upstream.h"
+#else
+
 #include "ngx_http_mruby_upstream.h"
 #include "ngx_http_mruby_request.h"
 
@@ -167,3 +173,5 @@ void ngx_mrb_upstream_class_init(mrb_state *mrb, struct RClass *class)
   mrb_define_method(mrb, class_upstream, "server", ngx_mrb_upstream_get_server, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_upstream, "server=", ngx_mrb_upstream_set_server, MRB_ARGS_REQ(1));
 }
+
+#endif /* NGX_USE_MRUBY_UPSTREAM */

--- a/src/ngx_http_mruby_upstream.c
+++ b/src/ngx_http_mruby_upstream.c
@@ -125,7 +125,7 @@ static mrb_value ngx_mrb_upstream_get_cache(mrb_state *mrb, mrb_value self)
   return mrb_fixnum_value(kcf->max_cached);
 }
 
-static mrb_value ngx_mrb_upstream_get_hostname(mrb_state *mrb, mrb_value self)
+static mrb_value ngx_mrb_upstream_get_server(mrb_state *mrb, mrb_value self)
 {
   ngx_mruby_upstream_context *ctx = DATA_PTR(self);
   if (ctx->target == NULL) {
@@ -134,7 +134,7 @@ static mrb_value ngx_mrb_upstream_get_hostname(mrb_state *mrb, mrb_value self)
   return mrb_str_new(mrb, (char *)ctx->target->name.data, ctx->target->name.len);
 }
 
-static mrb_value ngx_mrb_upstream_set_hostname(mrb_state *mrb, mrb_value self)
+static mrb_value ngx_mrb_upstream_set_server(mrb_state *mrb, mrb_value self)
 {
   ngx_mruby_upstream_context *ctx = DATA_PTR(self);
   ngx_url_t u;
@@ -176,6 +176,6 @@ void ngx_mrb_upstream_class_init(mrb_state *mrb, struct RClass *class)
   mrb_define_method(mrb, class_upstream, "initialize", ngx_mrb_upstream_init, MRB_ARGS_REQ(2));
   mrb_define_method(mrb, class_upstream, "keepalive_cache", ngx_mrb_upstream_get_cache, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_upstream, "keepalive_cache=", ngx_mrb_upstream_set_cache, MRB_ARGS_REQ(1));
-  mrb_define_method(mrb, class_upstream, "hostname", ngx_mrb_upstream_get_hostname, MRB_ARGS_NONE());
-  mrb_define_method(mrb, class_upstream, "hostname=", ngx_mrb_upstream_set_hostname, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, class_upstream, "server", ngx_mrb_upstream_get_server, MRB_ARGS_NONE());
+  mrb_define_method(mrb, class_upstream, "server=", ngx_mrb_upstream_set_server, MRB_ARGS_REQ(1));
 }

--- a/src/ngx_http_mruby_upstream.c
+++ b/src/ngx_http_mruby_upstream.c
@@ -1,0 +1,45 @@
+/*
+// ngx_http_mruby_upstream.c - ngx_mruby mruby module
+//
+// See Copyright Notice in ngx_http_mruby_module.c
+*/
+
+#include "ngx_http_mruby_upstream.h"
+
+#include <mruby.h>
+#include <mruby/proc.h>
+#include <mruby/data.h>
+#include <mruby/compile.h>
+#include <mruby/string.h>
+#include <mruby/class.h>
+
+static mrb_value ngx_mrb_upstream_init(mrb_state *mrb, mrb_value self)
+{
+  return mrb_nil_value();
+}
+
+static mrb_value ngx_mrb_upstream_set_keepalive(mrb_state *mrb, mrb_value self)
+{
+  return mrb_nil_value();
+}
+
+static mrb_value ngx_mrb_upstream_set_cache(mrb_state *mrb, mrb_value self)
+{
+  return mrb_nil_value();
+}
+
+static mrb_value ngx_mrb_upstream_get_hostname(mrb_state *mrb, mrb_value self)
+{
+  return mrb_nil_value();
+}
+
+void ngx_mrb_upstream_class_init(mrb_state *mrb, struct RClass *class)
+{
+  struct RClass *class_upstream;
+
+  class_upstream = mrb_define_class_under(mrb, class, "Upstream", mrb->object_class);
+  mrb_define_method(mrb, class_upstream, "initialize", ngx_mrb_upstream_init, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, class_upstream, "keepalive=", ngx_mrb_upstream_set_keepalive, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, class_upstream, "keepalive_cache=", ngx_mrb_upstream_set_cache, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, class_upstream, "hostname", ngx_mrb_upstream_get_hostname, MRB_ARGS_NONE());
+}

--- a/src/ngx_http_mruby_upstream.h
+++ b/src/ngx_http_mruby_upstream.h
@@ -1,0 +1,15 @@
+/*
+// ngx_http_mruby_upstream.h - ngx_mruby mruby module header
+//
+// See Copyright Notice in ngx_http_mruby_module.c
+*/
+
+#ifndef NGX_HTTP_MRUBY_UPSTREAM_H
+#define NGX_HTTP_MRUBY_UPSTREAM_H
+
+#include <ngx_http.h>
+#include <mruby.h>
+#include <mruby/hash.h>
+#include <mruby/variable.h>
+
+#endif // NGX_HTTP_MRUBY_UPSTREAM_H

--- a/src/ngx_http_mruby_upstream.h
+++ b/src/ngx_http_mruby_upstream.h
@@ -11,13 +11,8 @@
 #include <mruby/hash.h>
 #include <mruby/variable.h>
 
-/*
-#include <ngx_config.h>
-#include <ngx_core.h>
-#include <ngx_http.h>
-*/
 
-
+/* reference from src/http/modules/ngx_http_upstream_keepalive_module.c */
 
 /*
  * Copyright (C) Maxim Dounin

--- a/src/ngx_http_mruby_upstream.h
+++ b/src/ngx_http_mruby_upstream.h
@@ -7,9 +7,534 @@
 #ifndef NGX_HTTP_MRUBY_UPSTREAM_H
 #define NGX_HTTP_MRUBY_UPSTREAM_H
 
-#include <ngx_http.h>
 #include <mruby.h>
 #include <mruby/hash.h>
 #include <mruby/variable.h>
+
+/*
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+*/
+
+
+
+/*
+ * Copyright (C) Maxim Dounin
+ * Copyright (C) Nginx, Inc.
+ */
+
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+
+typedef struct {
+    ngx_uint_t                         max_cached;
+
+    ngx_queue_t                        cache;
+    ngx_queue_t                        free;
+
+    ngx_http_upstream_init_pt          original_init_upstream;
+    ngx_http_upstream_init_peer_pt     original_init_peer;
+
+} __ngx_http_upstream_keepalive_srv_conf_t;
+
+
+typedef struct {
+    __ngx_http_upstream_keepalive_srv_conf_t  *conf;
+
+    ngx_http_upstream_t               *upstream;
+
+    void                              *data;
+
+    ngx_event_get_peer_pt              original_get_peer;
+    ngx_event_free_peer_pt             original_free_peer;
+
+#if (NGX_HTTP_SSL)
+    ngx_event_set_peer_session_pt      original_set_session;
+    ngx_event_save_peer_session_pt     original_save_session;
+#endif
+
+} __ngx_http_upstream_keepalive_peer_data_t;
+
+
+typedef struct {
+    __ngx_http_upstream_keepalive_srv_conf_t  *conf;
+
+    ngx_queue_t                        queue;
+    ngx_connection_t                  *connection;
+
+    socklen_t                          socklen;
+    u_char                             sockaddr[NGX_SOCKADDRLEN];
+
+} __ngx_http_upstream_keepalive_cache_t;
+
+
+static ngx_int_t __ngx_http_upstream_init_keepalive_peer(ngx_http_request_t *r,
+    ngx_http_upstream_srv_conf_t *us);
+static ngx_int_t __ngx_http_upstream_get_keepalive_peer(ngx_peer_connection_t *pc,
+    void *data);
+static void __ngx_http_upstream_free_keepalive_peer(ngx_peer_connection_t *pc,
+    void *data, ngx_uint_t state);
+
+static void __ngx_http_upstream_keepalive_dummy_handler(ngx_event_t *ev);
+static void __ngx_http_upstream_keepalive_close_handler(ngx_event_t *ev);
+static void __ngx_http_upstream_keepalive_close(ngx_connection_t *c);
+
+
+#if (NGX_HTTP_SSL)
+static ngx_int_t __ngx_http_upstream_keepalive_set_session(
+    ngx_peer_connection_t *pc, void *data);
+static void __ngx_http_upstream_keepalive_save_session(ngx_peer_connection_t *pc,
+    void *data);
+#endif
+
+static void *__ngx_http_upstream_keepalive_create_conf(ngx_conf_t *cf);
+static char *__ngx_http_upstream_keepalive(ngx_conf_t *cf, ngx_command_t *cmd,
+    void *conf);
+
+
+static ngx_command_t  __ngx_http_upstream_keepalive_commands[] = {
+
+    { ngx_string("mruby_upstream_keepalive"),
+      NGX_HTTP_UPS_CONF|NGX_CONF_TAKE1,
+      __ngx_http_upstream_keepalive,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      0,
+      NULL },
+
+      ngx_null_command
+};
+
+
+static ngx_http_module_t  __ngx_http_upstream_keepalive_module_ctx = {
+    NULL,                                  /* preconfiguration */
+    NULL,                                  /* postconfiguration */
+
+    NULL,                                  /* create main configuration */
+    NULL,                                  /* init main configuration */
+
+    __ngx_http_upstream_keepalive_create_conf, /* create server configuration */
+    NULL,                                  /* merge server configuration */
+
+    NULL,                                  /* create location configuration */
+    NULL                                   /* merge location configuration */
+};
+
+
+ngx_module_t  __ngx_http_upstream_keepalive_module = {
+    NGX_MODULE_V1,
+    &__ngx_http_upstream_keepalive_module_ctx, /* module context */
+    __ngx_http_upstream_keepalive_commands,    /* module directives */
+    NGX_HTTP_MODULE,                       /* module type */
+    NULL,                                  /* init master */
+    NULL,                                  /* init module */
+    NULL,                                  /* init process */
+    NULL,                                  /* init thread */
+    NULL,                                  /* exit thread */
+    NULL,                                  /* exit process */
+    NULL,                                  /* exit master */
+    NGX_MODULE_V1_PADDING
+};
+
+
+static ngx_int_t
+__ngx_http_upstream_init_keepalive(ngx_conf_t *cf,
+    ngx_http_upstream_srv_conf_t *us)
+{
+    ngx_uint_t                               i;
+    __ngx_http_upstream_keepalive_srv_conf_t  *kcf;
+    __ngx_http_upstream_keepalive_cache_t     *cached;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, cf->log, 0,
+                   "init keepalive");
+
+    kcf = ngx_http_conf_upstream_srv_conf(us,
+                                          __ngx_http_upstream_keepalive_module);
+
+    if (kcf->original_init_upstream(cf, us) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    kcf->original_init_peer = us->peer.init;
+
+    us->peer.init = __ngx_http_upstream_init_keepalive_peer;
+
+    /* allocate cache items and add to free queue */
+
+    cached = ngx_pcalloc(cf->pool,
+                sizeof(__ngx_http_upstream_keepalive_cache_t) * kcf->max_cached);
+    if (cached == NULL) {
+        return NGX_ERROR;
+    }
+
+    ngx_queue_init(&kcf->cache);
+    ngx_queue_init(&kcf->free);
+
+    for (i = 0; i < kcf->max_cached; i++) {
+        ngx_queue_insert_head(&kcf->free, &cached[i].queue);
+        cached[i].conf = kcf;
+    }
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+__ngx_http_upstream_init_keepalive_peer(ngx_http_request_t *r,
+    ngx_http_upstream_srv_conf_t *us)
+{
+    __ngx_http_upstream_keepalive_peer_data_t  *kp;
+    __ngx_http_upstream_keepalive_srv_conf_t   *kcf;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "init keepalive peer");
+
+    kcf = ngx_http_conf_upstream_srv_conf(us,
+                                          __ngx_http_upstream_keepalive_module);
+
+    kp = ngx_palloc(r->pool, sizeof(__ngx_http_upstream_keepalive_peer_data_t));
+    if (kp == NULL) {
+        return NGX_ERROR;
+    }
+
+    if (kcf->original_init_peer(r, us) != NGX_OK) {
+        return NGX_ERROR;
+    }
+
+    kp->conf = kcf;
+    kp->upstream = r->upstream;
+    kp->data = r->upstream->peer.data;
+    kp->original_get_peer = r->upstream->peer.get;
+    kp->original_free_peer = r->upstream->peer.free;
+
+    r->upstream->peer.data = kp;
+    r->upstream->peer.get = __ngx_http_upstream_get_keepalive_peer;
+    r->upstream->peer.free = __ngx_http_upstream_free_keepalive_peer;
+
+#if (NGX_HTTP_SSL)
+    kp->original_set_session = r->upstream->peer.set_session;
+    kp->original_save_session = r->upstream->peer.save_session;
+    r->upstream->peer.set_session = __ngx_http_upstream_keepalive_set_session;
+    r->upstream->peer.save_session = __ngx_http_upstream_keepalive_save_session;
+#endif
+
+    return NGX_OK;
+}
+
+
+static ngx_int_t
+__ngx_http_upstream_get_keepalive_peer(ngx_peer_connection_t *pc, void *data)
+{
+    __ngx_http_upstream_keepalive_peer_data_t  *kp = data;
+    __ngx_http_upstream_keepalive_cache_t      *item;
+
+    ngx_int_t          rc;
+    ngx_queue_t       *q, *cache;
+    ngx_connection_t  *c;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "get keepalive peer");
+
+    /* ask balancer */
+
+    rc = kp->original_get_peer(pc, kp->data);
+
+    if (rc != NGX_OK) {
+        return rc;
+    }
+
+    /* search cache for suitable connection */
+
+    cache = &kp->conf->cache;
+
+    for (q = ngx_queue_head(cache);
+         q != ngx_queue_sentinel(cache);
+         q = ngx_queue_next(q))
+    {
+        item = ngx_queue_data(q, __ngx_http_upstream_keepalive_cache_t, queue);
+        c = item->connection;
+
+        if (ngx_memn2cmp((u_char *) &item->sockaddr, (u_char *) pc->sockaddr,
+                         item->socklen, pc->socklen)
+            == 0)
+        {
+            ngx_queue_remove(q);
+            ngx_queue_insert_head(&kp->conf->free, q);
+
+            ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                           "get keepalive peer: using connection %p", c);
+
+            c->idle = 0;
+            c->sent = 0;
+            c->log = pc->log;
+            c->read->log = pc->log;
+            c->write->log = pc->log;
+            c->pool->log = pc->log;
+
+            pc->connection = c;
+            pc->cached = 1;
+
+            return NGX_DONE;
+        }
+    }
+
+    return NGX_OK;
+}
+
+
+static void
+__ngx_http_upstream_free_keepalive_peer(ngx_peer_connection_t *pc, void *data,
+    ngx_uint_t state)
+{
+    __ngx_http_upstream_keepalive_peer_data_t  *kp = data;
+    __ngx_http_upstream_keepalive_cache_t      *item;
+
+    ngx_queue_t          *q;
+    ngx_connection_t     *c;
+    ngx_http_upstream_t  *u;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "free keepalive peer");
+
+    /* cache valid connections */
+
+    u = kp->upstream;
+    c = pc->connection;
+
+    if (state & NGX_PEER_FAILED
+        || c == NULL
+        || c->read->eof
+        || c->read->error
+        || c->read->timedout
+        || c->write->error
+        || c->write->timedout)
+    {
+        goto invalid;
+    }
+
+    if (!u->keepalive) {
+        goto invalid;
+    }
+
+    if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+        goto invalid;
+    }
+
+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+                   "free keepalive peer: saving connection %p", c);
+
+    if (ngx_queue_empty(&kp->conf->free)) {
+
+        q = ngx_queue_last(&kp->conf->cache);
+        ngx_queue_remove(q);
+
+        item = ngx_queue_data(q, __ngx_http_upstream_keepalive_cache_t, queue);
+
+        __ngx_http_upstream_keepalive_close(item->connection);
+
+    } else {
+        q = ngx_queue_head(&kp->conf->free);
+        ngx_queue_remove(q);
+
+        item = ngx_queue_data(q, __ngx_http_upstream_keepalive_cache_t, queue);
+    }
+
+    item->connection = c;
+    ngx_queue_insert_head(&kp->conf->cache, q);
+
+    pc->connection = NULL;
+
+    if (c->read->timer_set) {
+        ngx_del_timer(c->read);
+    }
+    if (c->write->timer_set) {
+        ngx_del_timer(c->write);
+    }
+
+    c->write->handler = __ngx_http_upstream_keepalive_dummy_handler;
+    c->read->handler = __ngx_http_upstream_keepalive_close_handler;
+
+    c->data = item;
+    c->idle = 1;
+    c->log = ngx_cycle->log;
+    c->read->log = ngx_cycle->log;
+    c->write->log = ngx_cycle->log;
+    c->pool->log = ngx_cycle->log;
+
+    item->socklen = pc->socklen;
+    ngx_memcpy(&item->sockaddr, pc->sockaddr, pc->socklen);
+
+    if (c->read->ready) {
+        __ngx_http_upstream_keepalive_close_handler(c->read);
+    }
+
+invalid:
+
+    kp->original_free_peer(pc, kp->data, state);
+}
+
+
+static void
+__ngx_http_upstream_keepalive_dummy_handler(ngx_event_t *ev)
+{
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ev->log, 0,
+                   "keepalive dummy handler");
+}
+
+
+static void
+__ngx_http_upstream_keepalive_close_handler(ngx_event_t *ev)
+{
+    __ngx_http_upstream_keepalive_srv_conf_t  *conf;
+    __ngx_http_upstream_keepalive_cache_t     *item;
+
+    int                n;
+    char               buf[1];
+    ngx_connection_t  *c;
+
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, ev->log, 0,
+                   "keepalive close handler");
+
+    c = ev->data;
+
+    if (c->close) {
+        goto close;
+    }
+
+    n = recv(c->fd, buf, 1, MSG_PEEK);
+
+    if (n == -1 && ngx_socket_errno == NGX_EAGAIN) {
+        ev->ready = 0;
+
+        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
+            goto close;
+        }
+
+        return;
+    }
+
+close:
+
+    item = c->data;
+    conf = item->conf;
+
+    __ngx_http_upstream_keepalive_close(c);
+
+    ngx_queue_remove(&item->queue);
+    ngx_queue_insert_head(&conf->free, &item->queue);
+}
+
+
+static void
+__ngx_http_upstream_keepalive_close(ngx_connection_t *c)
+{
+
+#if (NGX_HTTP_SSL)
+
+    if (c->ssl) {
+        c->ssl->no_wait_shutdown = 1;
+        c->ssl->no_send_shutdown = 1;
+
+        if (ngx_ssl_shutdown(c) == NGX_AGAIN) {
+            c->ssl->handler = __ngx_http_upstream_keepalive_close;
+            return;
+        }
+    }
+
+#endif
+
+    ngx_destroy_pool(c->pool);
+    ngx_close_connection(c);
+}
+
+
+#if (NGX_HTTP_SSL)
+
+static ngx_int_t
+__ngx_http_upstream_keepalive_set_session(ngx_peer_connection_t *pc, void *data)
+{
+    __ngx_http_upstream_keepalive_peer_data_t  *kp = data;
+
+    return kp->original_set_session(pc, kp->data);
+}
+
+
+static void
+__ngx_http_upstream_keepalive_save_session(ngx_peer_connection_t *pc, void *data)
+{
+    __ngx_http_upstream_keepalive_peer_data_t  *kp = data;
+
+    kp->original_save_session(pc, kp->data);
+    return;
+}
+
+#endif
+
+
+void *
+__ngx_http_upstream_keepalive_create_conf(ngx_conf_t *cf)
+{
+    __ngx_http_upstream_keepalive_srv_conf_t  *conf;
+
+    conf = ngx_pcalloc(cf->pool,
+                       sizeof(__ngx_http_upstream_keepalive_srv_conf_t));
+    if (conf == NULL) {
+        return NULL;
+    }
+
+    /*
+     * set by ngx_pcalloc():
+     *
+     *     conf->original_init_upstream = NULL;
+     *     conf->original_init_peer = NULL;
+     */
+
+    conf->max_cached = 1;
+
+    return conf;
+}
+
+
+static char *
+__ngx_http_upstream_keepalive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    ngx_http_upstream_srv_conf_t            *uscf;
+    __ngx_http_upstream_keepalive_srv_conf_t  *kcf = conf;
+
+    ngx_int_t    n;
+    ngx_str_t   *value;
+
+    uscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_module);
+
+    if (kcf->original_init_upstream) {
+        return "is duplicate";
+    }
+
+    kcf->original_init_upstream = uscf->peer.init_upstream
+                                  ? uscf->peer.init_upstream
+                                  : ngx_http_upstream_init_round_robin;
+
+    uscf->peer.init_upstream = __ngx_http_upstream_init_keepalive;
+
+    /* read options */
+
+    value = cf->args->elts;
+
+    n = ngx_atoi(value[1].data, value[1].len);
+
+    if (n == NGX_ERROR || n == 0) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                           "invalid value \"%V\" in \"%V\" directive",
+                           &value[1], &cmd->name);
+        return NGX_CONF_ERROR;
+    }
+
+    kcf->max_cached = n;
+
+    return NGX_CONF_OK;
+}
 
 #endif // NGX_HTTP_MRUBY_UPSTREAM_H

--- a/test/build_config.rb
+++ b/test/build_config.rb
@@ -29,7 +29,7 @@ MRuby::Build.new do |conf|
   conf.gem :github => 'iij/mruby-socket'
   conf.gem :github => 'iij/mruby-pack'
   # include the default GEMs
-  conf.gembox 'default'
+  conf.gembox 'full-core'
 
   # C compiler settings
   # conf.cc do |cc|

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -345,10 +345,10 @@ http {
           mruby_rewrite_handler_code '
             u = Nginx::Upstream.new "dummy", "127.0.0.1:80"
             # default: 1
-            u.hostname = "127.0.0.1:58081"
+            u.server = "127.0.0.1:58081"
             Nginx.errlogger Nginx::LOG_NOTICE, "front: keepalive_cache: #{u.keepalive_cache}"
             Nginx.errlogger Nginx::LOG_NOTICE, "front: keepalive_cache: #{Nginx::Headers_in.new.all}"
-            Nginx.errlogger Nginx::LOG_NOTICE, "front: u.hostname: #{u.hostname}"
+            Nginx.errlogger Nginx::LOG_NOTICE, "front: u.hostname: #{u.server}"
           ';
           proxy_pass http://dummy/keepalive;
           proxy_http_version 1.1;

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -339,7 +339,7 @@ http {
         # test for upstream keepalive
         location /upstream-keepalive {
           mruby_set_code $backend '
-            u = Nginx::Upstreame.new "127.0.0.1:58081"
+            u = Nginx::Upstream.new "127.0.0.1:58081"
             u.keepalive = true
             u.keepalive_cache = 32
             u.hostname

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -38,10 +38,10 @@ http {
         }
     }
 
-    upstream dummy {
-      server 127.0.0.1;
-      mruby_upstream_keepalive 1;
-    }
+    #upstream dummy {
+    #  server 127.0.0.1;
+    #  #mruby_upstream_keepalive 1;
+    #}
 
     server {
         listen       58080;
@@ -347,6 +347,7 @@ http {
             u = Nginx::Upstream.new "127.0.0.1:58081"
             u.keepalive = true
             u.keepalive_cache = 32
+            Nginx.errlogger Nginx::LOG_NOTICE, "keepalive_cache: #{u.keepalive_cache}"
             u.hostname
           ';
           proxy_pass http://$backend/keepalive;

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -355,6 +355,9 @@ http {
           proxy_read_timeout 2s;
           proxy_connect_timeout 2s;
         }
+        location /nginx-version {
+          mruby_content_handler_code 'Nginx.rputs Nginx.nginx_version';
+        }
     }
     upstream mruby_upstream {
       server 127.0.0.1:80;

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -29,6 +29,10 @@ http {
         listen       58081;
         server_name  localhost;
 
+        location /keepalive {
+            # If using keepalive, return true
+            mruby_content_handler_code "Nginx.rputs Nginx::Request.new.headers_in['Connection'].nil?.to_s";
+        }
         location / {
             mruby_content_handler_code "Nginx.rputs 'proxy test ok'";
         }
@@ -331,6 +335,17 @@ http {
         }
         # test for rewrite built-in Server header
         mruby_server_rewrite_handler_code 'Nginx::Request.new.headers_out["Server"] = "global_ngx_mruby"; Nginx.return Nginx::DECLINED';
+
+        # test for upstream keepalive
+        location /upstream-keepalive {
+          mruby_set_code $backend '
+            u = Nginx::Upstreame.new "127.0.0.1:58081"
+            u.keepalive = true
+            u.keepalive_cache = 32
+            u.hostname
+          ';
+          proxy_pass  http://$backend/keepalive;
+        }
     }
 }
 

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -38,6 +38,11 @@ http {
         }
     }
 
+    upstream dummy {
+      server 127.0.0.1;
+      mruby_upstream_keepalive 1;
+    }
+
     server {
         listen       58080;
         server_name  localhost;
@@ -344,7 +349,12 @@ http {
             u.keepalive_cache = 32
             u.hostname
           ';
-          proxy_pass  http://$backend/keepalive;
+          proxy_pass http://$backend/keepalive;
+          proxy_http_version 1.1;
+          proxy_set_header Connection "";
+          proxy_send_timeout 2s;
+          proxy_read_timeout 2s;
+          proxy_connect_timeout 2s;
         }
     }
 }

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -33,7 +33,8 @@ http {
             # If using keepalive, return true
             mruby_content_handler_code '
               Nginx.rputs Nginx::Request.new.headers_in["Connection"].nil?.to_s
-              Nginx.errlogger Nginx::LOG_NOTICE, "remote_port: #{Nginx::Connection.new.remote_port}"
+              Nginx.errlogger Nginx::LOG_NOTICE, "upstream: remote_port: #{Nginx::Connection.new.remote_port}"
+              Nginx.errlogger Nginx::LOG_NOTICE, "upstream: request_header:: #{Nginx::Headers_in.new.all}"
             ';
         }
         location / {
@@ -341,20 +342,25 @@ http {
 
         # test for upstream keepalive
         location /upstream-keepalive {
-          mruby_set_code $backend '
-            u = Nginx::Upstream.new "127.0.0.1:58081"
+          mruby_rewrite_handler_code '
+            u = Nginx::Upstream.new "dummy", "127.0.0.1:80"
             # default: 1
-            u.keepalive_cache = 32
-            Nginx.errlogger Nginx::LOG_NOTICE, "keepalive_cache: #{u.keepalive_cache}"
-            u.hostname
+            u.hostname = "127.0.0.1:58081"
+            Nginx.errlogger Nginx::LOG_NOTICE, "front: keepalive_cache: #{u.keepalive_cache}"
+            Nginx.errlogger Nginx::LOG_NOTICE, "front: keepalive_cache: #{Nginx::Headers_in.new.all}"
+            Nginx.errlogger Nginx::LOG_NOTICE, "front: u.hostname: #{u.hostname}"
           ';
-          proxy_pass http://$backend/keepalive;
+          proxy_pass http://dummy/keepalive;
           proxy_http_version 1.1;
           proxy_set_header Connection "";
           proxy_send_timeout 2s;
           proxy_read_timeout 2s;
           proxy_connect_timeout 2s;
         }
+    }
+    upstream dummy {
+      server 127.0.0.1:80;
+      mruby_upstream_keepalive 16;
     }
 }
 

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -343,14 +343,12 @@ http {
         # test for upstream keepalive
         location /upstream-keepalive {
           mruby_rewrite_handler_code '
-            u = Nginx::Upstream.new "dummy", "127.0.0.1:80"
-            # default: 1
+            u = Nginx::Upstream.new "mruby_upstream"
             u.server = "127.0.0.1:58081"
             Nginx.errlogger Nginx::LOG_NOTICE, "front: keepalive_cache: #{u.keepalive_cache}"
-            Nginx.errlogger Nginx::LOG_NOTICE, "front: keepalive_cache: #{Nginx::Headers_in.new.all}"
             Nginx.errlogger Nginx::LOG_NOTICE, "front: u.hostname: #{u.server}"
           ';
-          proxy_pass http://dummy/keepalive;
+          proxy_pass http://mruby_upstream/keepalive;
           proxy_http_version 1.1;
           proxy_set_header Connection "";
           proxy_send_timeout 2s;
@@ -358,7 +356,7 @@ http {
           proxy_connect_timeout 2s;
         }
     }
-    upstream dummy {
+    upstream mruby_upstream {
       server 127.0.0.1:80;
       mruby_upstream_keepalive 16;
     }

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -38,11 +38,6 @@ http {
         }
     }
 
-    #upstream dummy {
-    #  server 127.0.0.1;
-    #  #mruby_upstream_keepalive 1;
-    #}
-
     server {
         listen       58080;
         server_name  localhost;

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -340,7 +340,7 @@ http {
         location /upstream-keepalive {
           mruby_set_code $backend '
             u = Nginx::Upstream.new "127.0.0.1:58081"
-            u.keepalive = true
+            # default: 1
             u.keepalive_cache = 32
             Nginx.errlogger Nginx::LOG_NOTICE, "keepalive_cache: #{u.keepalive_cache}"
             u.hostname

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -204,4 +204,9 @@ t.assert('ngx_mruby - update built-in response header in http context', 'locatio
   t.assert_equal "global_ngx_mruby", res["server"]
 end
 
+t.assert('ngx_mruby - upstream keepalive', 'location /upstream-keepalive') do
+  res = HttpRequest.new.get base + '/upstream-keepalive'
+  t.assert_equal "true", res["body"]
+end
+
 t.report

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -7,6 +7,8 @@ end
 
 t = SimpleTest.new "ngx_mruby test"
 
+nginx_version = HttpRequest.new.get(base + '/nginx-version')["body"]
+
 t.assert('ngx_mruby', 'location /mruby') do
   res = HttpRequest.new.get base + '/mruby'
   t.assert_equal 'Hello ngx_mruby world!', res["body"]
@@ -204,9 +206,13 @@ t.assert('ngx_mruby - update built-in response header in http context', 'locatio
   t.assert_equal "global_ngx_mruby", res["server"]
 end
 
-t.assert('ngx_mruby - upstream keepalive', 'location /upstream-keepalive') do
-  res = HttpRequest.new.get base + '/upstream-keepalive'
-  t.assert_equal "true", res["body"]
+p nginx_version
+
+if nginx_version.split(".")[1].to_i > 6
+  t.assert('ngx_mruby - upstream keepalive', 'location /upstream-keepalive') do
+    res = HttpRequest.new.get base + '/upstream-keepalive'
+    t.assert_equal "true", res["body"]
+  end
 end
 
 t.report


### PR DESCRIPTION
Add upstream class and methods. After merging this pull-request, ngx_mruby can setup upstream keepalive configuration per upstream host in Ruby code.
 
```nginx
        location /upstream-keepalive {
          mruby_set_code $backend '
            u = Nginx::Upstreame.new "127.0.0.1:58081"
            u.keepalive = true
            u.keepalive_cache = 32
            u.hostname
          ';
          proxy_pass  http://$backend/keepalive;
        }
```