### PR TITLE
Implement Var#exist?

### DIFF
--- a/src/ngx_http_mruby_var.c
+++ b/src/ngx_http_mruby_var.c
@@ -204,6 +204,32 @@ static mrb_value ngx_mrb_var_method_missing(mrb_state *mrb, mrb_value self)
   }
 }
 
+static mrb_value ngx_mrb_var_exist(mrb_state *mrb, mrb_value self)
+{
+  mrb_int m_len;
+  char *c_name;
+
+  ngx_http_request_t *r;
+  ngx_http_variable_value_t *var;
+  ngx_str_t ngx_name;
+  ngx_uint_t key;
+
+  r = ngx_mrb_get_request();
+
+  mrb_get_args(mrb, "s", &c_name, &m_len);
+
+  ngx_name.len = (size_t)m_len;
+  ngx_name.data = (u_char *)c_name;
+
+  key = ngx_hash_strlow(ngx_name.data, ngx_name.data, ngx_name.len);
+  var = ngx_http_get_variable(r, &ngx_name, key);
+  if (var != NULL && !var->not_found) {
+    return mrb_true_value();
+  }
+
+  return mrb_false_value();
+}
+
 static mrb_value ngx_mrb_var_set_func(mrb_state *mrb, mrb_value self)
 {
   ngx_http_request_t *r;
@@ -347,5 +373,6 @@ void ngx_mrb_var_class_init(mrb_state *mrb, struct RClass *class)
 
   class_var = mrb_define_class_under(mrb, class, "Var", mrb->object_class);
   mrb_define_method(mrb, class_var, "method_missing", ngx_mrb_var_method_missing, MRB_ARGS_ANY());
+  mrb_define_method(mrb, class_var, "exist?", ngx_mrb_var_exist, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, class_var, "set", ngx_mrb_var_set_func, MRB_ARGS_REQ(2));
 }

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -367,6 +367,9 @@ http {
         location /hostname {
           mruby_content_handler_code 'Nginx.rputs Nginx::Request.new.hostname.to_s';
         }
+        location /var_exist {
+          mruby_content_handler_code 'Nginx.rputs Nginx::Request.new.var.exist?("arg_foo").to_s';
+        }
     }
     upstream mruby_upstream {
       server 127.0.0.1:80;

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -235,4 +235,12 @@ t.assert('ngx_mruby - hostname', 'location /hostname') do
   t.assert_equal "127.0.0.1", res["body"]
 end
 
+t.assert('ngx_mruby - Var#exist?', 'location /var_exist') do
+  res = HttpRequest.new.get base + '/var_exist'
+  t.assert_equal "false", res["body"]
+
+  res = HttpRequest.new.get base + '/var_exist?foo=bar'
+  t.assert_equal "true", res["body"]
+end
+
 t.report


### PR DESCRIPTION
`Var#exist?(var_name)` returns true when the nginx variable is found, otherwise it returns false.

## Purpose

`Var#method_missing` returns nil if the variable doesn't exist or is not found and it also logs an error like `ngx_mruby ERROR ngx_mrb_var_get:57: arg_foo not found`. I would like to check whether the variable exists for suppressing such an error log.

```ruby
r = Nginx::Request.new
Nginx.echo "foo: #{r.var.arg_foo}" if r.var.exist?("arg_foo")
```