### PR TITLE
Fix bug; mruby_set ignore "cache" option

### DIFF
--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -209,7 +209,7 @@ http {
         # test for control nginx internal varable between mruby and nginx
         location /inter_var_file {
             set $fuga "200";
-            mruby_set $hoge "build/nginx/html/set.rb";
+            mruby_set $hoge "build/nginx/html/set.rb" cache;
             mruby_content_handler "build/nginx/html/set2.rb";
         }
 


### PR DESCRIPTION
`mruby_set` directive ignore cache option.

```
mruby_set $hoge hoge.rb cache
```

After starting nginx with above configuration, nginx also changes response if changing `hoge.rb`.