### PR TITLE
Allocate memory for mruby object instead of the ptr of mruby object

### DIFF
--- a/src/ngx_http_mruby_core.c
+++ b/src/ngx_http_mruby_core.c
@@ -338,11 +338,12 @@ static mrb_value ngx_mrb_redirect(mrb_state *mrb, mrb_value self)
   }
 
   // save location uri to ns
-  ns.data = (u_char *)mrb_str_to_cstr(mrb, uri);
   ns.len = RSTRING_LEN(uri);
   if (ns.len == 0) {
     return mrb_nil_value();
   }
+  ns.data = ngx_palloc(r->pool, ns.len);
+  ngx_memcpy(ns.data, RSTRING_PTR(uri), ns.len);
 
   // if uri start with scheme prefix
   // return 3xx for redirect

--- a/src/ngx_http_mruby_var.c
+++ b/src/ngx_http_mruby_var.c
@@ -166,7 +166,8 @@ static mrb_value ngx_mrb_var_exist(mrb_state *mrb, mrb_value self)
   mrb_get_args(mrb, "s", &c_name, &m_len);
 
   ngx_name.len = (size_t)m_len;
-  ngx_name.data = (u_char *)c_name;
+  ngx_name.data = ngx_palloc(r->pool, ngx_name.len);
+  ngx_memcpy(ngx_name.data, (u_char *)c_name, ngx_name.len);
 
   key = ngx_hash_strlow(ngx_name.data, ngx_name.data, ngx_name.len);
   var = ngx_http_get_variable(r, &ngx_name, key);

--- a/test.sh
+++ b/test.sh
@@ -74,7 +74,7 @@ sed -e "s|__NGXDOCROOT__|${NGINX_INSTALL_DIR}/html/|g" test/conf/nginx.conf > ${
 cp -pr test/html/* ${NGINX_INSTALL_DIR}/html/.
 
 ${NGINX_INSTALL_DIR}/sbin/nginx &
-sleep 2
+#sleep 2
 cp -p test/build_config.rb ./mruby_test/.
 cd mruby_test
 rake


### PR DESCRIPTION
ref: #131 