### PR TITLE
Support multipul headers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 # requires clang-format >= 3.6
 BasedOnStyle: "LLVM"
 IndentWidth: 2
-ColumnLimit: 80
+ColumnLimit: 120
 BreakBeforeBraces: Linux
 AllowShortFunctionsOnASingleLine: None

--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 # requires clang-format >= 3.6
 BasedOnStyle: "LLVM"
 IndentWidth: 2
-ColumnLimit: 120
+ColumnLimit: 80
 BreakBeforeBraces: Linux
 AllowShortFunctionsOnASingleLine: None

--- a/src/ngx_http_mruby_request.c
+++ b/src/ngx_http_mruby_request.c
@@ -337,8 +337,6 @@ static ngx_int_t ngx_mrb_set_request_header(mrb_state *mrb, ngx_list_t *headers,
 {
   u_char *key, *val;
   size_t key_len, val_len;
-  ngx_list_part_t *part;
-  ngx_table_elt_t *header;
   ngx_table_elt_t *new_header;
   ngx_http_request_t *r = ngx_mrb_get_request();
 
@@ -356,9 +354,6 @@ static ngx_int_t ngx_mrb_set_request_header(mrb_state *mrb, ngx_list_t *headers,
 
   ngx_memcpy(key, (u_char *)RSTRING_PTR(mrb_key), key_len);
   ngx_memcpy(val, (u_char *)RSTRING_PTR(mrb_val), val_len);
-
-  part = &headers->part;
-  header = part->elts;
 
   switch (ngx_mruby_builtin_header_lookup_token(key, key_len)) {
   case NGX_MRUBY_BUILDIN_HEADER_SERVER:

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -454,6 +454,23 @@ http {
             run p
           ';
         }
+        location /multi_headers_out {
+          mruby_content_handler_code '
+            r = Nginx::Request.new
+            r.headers_out["hoge"] = "dummy"
+            r.headers_out["hoge"] = %w(foo fuga)
+            Nginx.rputs r.headers_out["hoge"]
+            Nginx.return 200
+          ';
+        }
+        location /multi_headers_in {
+          mruby_content_handler_code '
+            r = Nginx::Request.new
+            r.headers_in["hoge"] = [r.headers_in["hoge"], "fuga"]
+            Nginx.rputs r.headers_in["hoge"]
+            Nginx.return 200
+          ';
+        }
     }
     upstream mruby_upstream {
       server 127.0.0.1:80;

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -317,4 +317,17 @@ t.assert('ngx_mruby - rack base push', 'location /rack_base_push/index.txt') do
   t.assert_equal "</index.js>; rel=preload", res["link"]
 end
 
+t.assert('ngx_mruby - multipul request headers', 'location /multi_headers_in') do
+  res = HttpRequest.new.get base + '/multi_headers_in', nil, {"hoge" => "foo"}
+  t.assert_equal 200, res.code
+  t.assert_equal '["fuga", "foo"]', res["body"]
+end
+
+t.assert('ngx_mruby - multipul response headers', 'location /multi_headers_out') do
+  res = HttpRequest.new.get base + '/multi_headers_out'
+  t.assert_equal 200, res.code
+  t.assert_equal '["fuga", "foo"]', res["body"]
+  t.assert_equal ["fuga", "foo"], res["hoge"]
+end
+
 t.report


### PR DESCRIPTION
- config

```nginx
        location /multi_headers_out {
          mruby_content_handler_code '
            r = Nginx::Request.new
            r.headers_out["hoge"] = "dummy"
            r.headers_out["hoge"] = %w(foo fuga)
            Nginx.rputs r.headers_out["hoge"]
            Nginx.return 200
          ';
        }
        location /multi_headers_in {
          mruby_content_handler_code '
            r = Nginx::Request.new
            r.headers_in["hoge"] = [r.headers_in["hoge"], "fuga"]
            Nginx.rputs r.headers_in["hoge"]
            Nginx.return 200
          ';
        }
```

- curl

```
$ curl -v http://127.0.0.1:58080/multi_headers_out
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 58080 (#0)
> GET /multi_headers_out HTTP/1.1
> Host: 127.0.0.1:58080
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Fri, 02 Oct 2015 07:32:53 GMT
< Content-Length: 15
< Connection: keep-alive
< Server: global_ngx_mruby
< hoge: fuga
< hoge: foo
< 
* Connection #0 to host 127.0.0.1 left intact
["fuga", "foo"]

$ curl -v http://127.0.0.1:58080/multi_headers_in -Hhoge:foo
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 58080 (#0)
> GET /multi_headers_in HTTP/1.1
> Host: 127.0.0.1:58080
> User-Agent: curl/7.43.0
> Accept: */*
> hoge:foo
> 
< HTTP/1.1 200 OK
< Date: Fri, 02 Oct 2015 07:33:19 GMT
< Content-Length: 15
< Connection: keep-alive
< Server: global_ngx_mruby
< 
* Connection #0 to host 127.0.0.1 left intact
["fuga", "foo"]
```