### PR TITLE
Support stream init and exit directives with mruby, and access control methods

### DIFF
--- a/src/stream/ngx_stream_mruby_connection.c
+++ b/src/stream/ngx_stream_mruby_connection.c
@@ -125,6 +125,25 @@ static mrb_value ngx_stream_mrb_upstream_set_server(mrb_state *mrb, mrb_value se
   return server;
 }
 
+static mrb_value ngx_stream_mrb_connection_get_status(mrb_state *mrb, mrb_value self)
+{
+  ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
+
+  return mrb_fixnum_value((mrb_int)ictx->stream_status);
+}
+
+static mrb_value ngx_stream_mrb_connection_status(mrb_state *mrb, mrb_value self)
+{
+  ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
+  mrb_int status;
+
+  mrb_get_args(mrb, "i", &status);
+
+  ictx->stream_status = (ngx_int_t)status;
+
+  return self;
+}
+
 static mrb_value ngx_stream_mrb_remote_ip(mrb_state *mrb, mrb_value self)
 {
   ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
@@ -141,5 +160,10 @@ void ngx_stream_mrb_conn_class_init(mrb_state *mrb, struct RClass *class)
   mrb_define_method(mrb, class_conn, "initialize", ngx_stream_mrb_connection_init, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, class_conn, "upstream_server", ngx_stream_mrb_upstream_get_server, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_conn, "upstream_server=", ngx_stream_mrb_upstream_set_server, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, class_conn, "stream_status", ngx_stream_mrb_connection_get_status, MRB_ARGS_NONE());
+  mrb_define_method(mrb, class_conn, "stream_status=", ngx_stream_mrb_connection_status, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, class_conn, "remote_ip", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, class_conn, "remote_ip", ngx_stream_mrb_remote_ip, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, class_conn, "stream_status", ngx_stream_mrb_connection_get_status, MRB_ARGS_NONE());
+  mrb_define_class_method(mrb, class_conn, "stream_status=", ngx_stream_mrb_connection_status, MRB_ARGS_REQ(1));
 }

--- a/src/stream/ngx_stream_mruby_connection.c
+++ b/src/stream/ngx_stream_mruby_connection.c
@@ -41,7 +41,8 @@ static mrb_value ngx_stream_mrb_connection_init(mrb_state *mrb, mrb_value self)
   ngx_stream_mruby_upstream_context *ctx;
   ngx_stream_upstream_main_conf_t *umcf;
   ngx_stream_upstream_srv_conf_t **usp;
-  ngx_stream_session_t *s = mrb->ud;
+  ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
+  ngx_stream_session_t *s = ictx->s;
 
   mrb_get_args(mrb, "o", &upstream);
 
@@ -100,7 +101,8 @@ static mrb_value ngx_stream_mrb_upstream_set_server(mrb_state *mrb, mrb_value se
   ngx_stream_mruby_upstream_context *ctx = DATA_PTR(self);
   ngx_url_t u;
   mrb_value server;
-  ngx_stream_session_t *s = mrb->ud;
+  ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
+  ngx_stream_session_t *s = ictx->s;
 
   mrb_get_args(mrb, "o", &server);
 
@@ -125,7 +127,8 @@ static mrb_value ngx_stream_mrb_upstream_set_server(mrb_state *mrb, mrb_value se
 
 static mrb_value ngx_stream_mrb_remote_ip(mrb_state *mrb, mrb_value self)
 {
-  ngx_stream_session_t *s = mrb->ud;
+  ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
+  ngx_stream_session_t *s = ictx->s;
 
   return mrb_str_new(mrb, (const char *)s->connection->addr_text.data, s->connection->addr_text.len);
 }

--- a/src/stream/ngx_stream_mruby_connection.h
+++ b/src/stream/ngx_stream_mruby_connection.h
@@ -7,4 +7,6 @@
 #ifndef NGX_STREAM_MRUBY_CONNECTION_H
 #define NGX_STREAM_MRUBY_CONNECTION_H
 
+#include "ngx_stream_mruby_module.h"
+
 #endif // NGX_STREAM_MRUBY_CONNECTION_H

--- a/src/stream/ngx_stream_mruby_core.c
+++ b/src/stream/ngx_stream_mruby_core.c
@@ -27,7 +27,9 @@ static mrb_value ngx_stream_mrb_errlogger(mrb_state *mrb, mrb_value self)
   mrb_value msg;
   mrb_int argc;
   mrb_int log_level;
-  ngx_stream_session_t *s = mrb->ud;
+  ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
+  ngx_stream_session_t *s = ictx->s;
+
   if (s == NULL) {
     mrb_raise(mrb, E_RUNTIME_ERROR, "can't use logger at this phase. only use at session stream phase");
   }

--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -7,7 +7,6 @@
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_stream.h>
-#include <ngx_conf_file.h>
 
 #include "mruby.h"
 #include "mruby/proc.h"
@@ -413,7 +412,7 @@ static char *ngx_stream_mruby_build_file(ngx_conf_t *cf, ngx_command_t *cmd, voi
 /* set directive values from inline code*/
 static char *ngx_stream_mruby_build_code(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
-  mrb_state *mrb = ngx_stream_mrb_state_conf(cf); 
+  mrb_state *mrb = ngx_stream_mrb_state_conf(cf);
   ngx_stream_mruby_srv_conf_t *ascf = conf;
   ngx_str_t *value;
   ngx_mrb_code_t *code;

--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -137,7 +137,7 @@ ngx_module_t ngx_stream_mruby_module = {NGX_MODULE_V1, &ngx_stream_mruby_module_
                                         ngx_stream_mruby_init_worker,                /* init process */
                                         NULL,                                        /* init thread */
                                         NULL,                                        /* exit thread */
-                                        ngx_stream_mruby_exit_worker,                                        /* exit process */
+                                        ngx_stream_mruby_exit_worker,                /* exit process */
                                         NULL,                                        /* exit master */
                                         NGX_MODULE_V1_PADDING};
 

--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -7,6 +7,7 @@
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_stream.h>
+#include <ngx_conf_file.h>
 
 #include "mruby.h"
 #include "mruby/proc.h"
@@ -19,37 +20,37 @@
 #include "ngx_stream_mruby_module.h"
 #include "ngx_stream_mruby_init.h"
 
-typedef enum code_type_t { NGX_MRB_CODE_TYPE_FILE, NGX_MRB_CODE_TYPE_STRING } code_type_t;
-
-typedef struct ngx_mrb_code_t {
-  union code {
-    char *file;
-    char *string;
-  } code;
-  code_type_t code_type;
-  struct RProc *proc;
-  mrbc_context *ctx;
-} ngx_mrb_code_t;
-
-typedef struct {
-
-  mrb_state *mrb;
-  ngx_mrb_code_t *code;
-
-} ngx_stream_mruby_srv_conf_t;
-
 static void ngx_stream_mruby_raise_error(mrb_state *mrb, mrb_value obj, ngx_stream_session_t *s);
 static ngx_int_t ngx_stream_mruby_handler(ngx_stream_session_t *s);
 static ngx_mrb_code_t *ngx_stream_mruby_mrb_code_from_file(ngx_pool_t *pool, ngx_str_t *code_s);
 static ngx_mrb_code_t *ngx_stream_mruby_mrb_code_from_string(ngx_pool_t *pool, ngx_str_t *code_s);
 static ngx_int_t ngx_stream_mruby_shared_state_compile(ngx_conf_t *cf, mrb_state *mrb, ngx_mrb_code_t *code);
+
+static char *ngx_stream_mruby_init_build_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static char *ngx_stream_mruby_init_build_code(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_stream_mruby_build_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_stream_mruby_build_code(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+
+static void *ngx_stream_mruby_create_main_conf(ngx_conf_t *cf);
+static char *ngx_stream_mruby_init_main_conf(ngx_conf_t *cf, void *conf);
 static void *ngx_stream_mruby_create_srv_conf(ngx_conf_t *cf);
 static char *ngx_stream_mruby_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child);
+
+static void ngx_stream_mrb_raise_cycle_error(mrb_state *mrb, mrb_value obj, ngx_cycle_t *cycle);
+static ngx_int_t ngx_stream_mrb_run_cycle(ngx_cycle_t *cycle, mrb_state *mrb, ngx_mrb_code_t *code);
+static ngx_int_t ngx_stream_mruby_init_module(ngx_cycle_t *cycle);
+
+// static void ngx_stream_mrb_raise_conf_error(mrb_state *mrb, mrb_value obj, ngx_conf_t *cf);
+// static ngx_int_t ngx_stream_mrb_run_conf(ngx_conf_t *cf, mrb_state *mrb, ngx_mrb_code_t *code);
 static ngx_int_t ngx_stream_mruby_init(ngx_conf_t *cf);
 
 static ngx_command_t ngx_stream_mruby_commands[] = {
+
+    {ngx_string("mruby_stream_init"), NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_stream_mruby_init_build_file, NGX_STREAM_SRV_CONF_OFFSET, 0, NULL},
+
+    {ngx_string("mruby_stream_init_code"), NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_stream_mruby_init_build_code, NGX_STREAM_SRV_CONF_OFFSET, 0, NULL},
 
     {ngx_string("mruby_stream"), NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1,
      ngx_stream_mruby_build_file, NGX_STREAM_SRV_CONF_OFFSET, 0, NULL},
@@ -62,8 +63,8 @@ static ngx_command_t ngx_stream_mruby_commands[] = {
 static ngx_stream_module_t ngx_stream_mruby_module_ctx = {
     ngx_stream_mruby_init, /* postconfiguration */
 
-    NULL, /* create main configuration */
-    NULL, /* init main configuration */
+    ngx_stream_mruby_create_main_conf, /* create main configuration */
+    ngx_stream_mruby_init_main_conf,   /* init main configuration */
 
     ngx_stream_mruby_create_srv_conf, /* create server configuration */
     ngx_stream_mruby_merge_srv_conf   /* merge server configuration */
@@ -73,13 +74,111 @@ ngx_module_t ngx_stream_mruby_module = {NGX_MODULE_V1, &ngx_stream_mruby_module_
                                         ngx_stream_mruby_commands,                   /* module directives */
                                         NGX_STREAM_MODULE,                           /* module type */
                                         NULL,                                        /* init master */
-                                        NULL,                                        /* init module */
+                                        ngx_stream_mruby_init_module,                /* init module */
                                         NULL,                                        /* init process */
                                         NULL,                                        /* init thread */
                                         NULL,                                        /* exit thread */
                                         NULL,                                        /* exit process */
                                         NULL,                                        /* exit master */
                                         NGX_MODULE_V1_PADDING};
+
+static void *ngx_stream_mruby_create_main_conf(ngx_conf_t *cf)
+{
+  ngx_stream_mruby_main_conf_t *mmcf;
+
+  mmcf = ngx_pcalloc(cf->pool, sizeof(ngx_stream_mruby_main_conf_t));
+  if (mmcf == NULL) {
+    return NULL;
+  }
+
+  mmcf->init_code = NGX_CONF_UNSET_PTR;
+  mmcf->mrb = mrb_open();
+  ngx_stream_mrb_class_init(mmcf->mrb);
+
+  return mmcf;
+}
+
+static char *ngx_stream_mruby_init_main_conf(ngx_conf_t *cf, void *conf)
+{
+  // ngx_stream_mruby_srv_conf_t *mscf = ngx_stream_conf_get_module_srv_conf(cf, ngx_stream_mruby_module);
+  // ngx_stream_mruby_main_conf_t *mmcf = conf;
+
+  // mmcf->mrb = mscf->mrb;
+
+  return NGX_CONF_OK;
+}
+
+/* create directive template */
+static void *ngx_stream_mruby_create_srv_conf(ngx_conf_t *cf)
+{
+  ngx_stream_mruby_srv_conf_t *ascf;
+
+  ascf = ngx_pcalloc(cf->pool, sizeof(ngx_stream_mruby_srv_conf_t));
+  if (ascf == NULL) {
+    return NULL;
+  }
+  ascf->code = NGX_CONF_UNSET_PTR;
+  ascf->mrb = mrb_open();
+  ngx_stream_mrb_class_init(ascf->mrb);
+
+  return ascf;
+}
+
+/* merge directive configuration */
+static char *ngx_stream_mruby_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+{
+  ngx_stream_mruby_srv_conf_t *prev = parent;
+  ngx_stream_mruby_srv_conf_t *conf = child;
+
+  if (conf->mrb == NULL) {
+    conf->mrb = prev->mrb;
+  }
+
+  if (conf->code == NGX_CONF_UNSET_PTR) {
+    conf->code = prev->code;
+  }
+
+  return NGX_CONF_OK;
+}
+
+static void ngx_stream_mrb_raise_cycle_error(mrb_state *mrb, mrb_value obj, ngx_cycle_t *cycle)
+{
+  struct RString *str;
+  char *err_out;
+
+  obj = mrb_funcall(mrb, obj, "inspect", 0);
+  if (mrb_type(obj) == MRB_TT_STRING) {
+    str = mrb_str_ptr(obj);
+    err_out = str->as.heap.ptr;
+    ngx_log_error(NGX_LOG_ERR, cycle->log, 0, "mrb_run failed. error: %s", err_out);
+  }
+}
+
+static ngx_int_t ngx_stream_mrb_run_cycle(ngx_cycle_t *cycle, mrb_state *mrb, ngx_mrb_code_t *code)
+{
+  mrb_int ai = mrb_gc_arena_save(mrb);
+
+  mrb_run(mrb, code->proc, mrb_top_self(mrb));
+  if (mrb->exc) {
+    ngx_stream_mrb_raise_cycle_error(mrb, mrb_obj_value(mrb->exc), cycle);
+    mrb_gc_arena_restore(mrb, ai);
+    return NGX_ERROR;
+  }
+
+  mrb_gc_arena_restore(mrb, ai);
+  return NGX_OK;
+}
+
+static ngx_int_t ngx_stream_mruby_init_module(ngx_cycle_t *cycle)
+{
+  ngx_stream_mruby_main_conf_t *mmcf = ngx_stream_cycle_get_module_main_conf(cycle, ngx_stream_mruby_module);
+
+  if (mmcf->init_code != NGX_CONF_UNSET_PTR) {
+    return ngx_stream_mrb_run_cycle(cycle, mmcf->mrb, mmcf->init_code);
+  }
+
+  return NGX_OK;
+}
 
 static void ngx_stream_mruby_raise_error(mrb_state *mrb, mrb_value obj, ngx_stream_session_t *s)
 {
@@ -205,6 +304,48 @@ static ngx_int_t ngx_stream_mruby_shared_state_compile(ngx_conf_t *cf, mrb_state
   return NGX_OK;
 }
 
+static char *ngx_stream_mruby_init_build_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+  ngx_int_t rc;
+  ngx_stream_mruby_main_conf_t *mmcf = ngx_stream_conf_get_module_main_conf(cf, ngx_stream_mruby_module);
+  ngx_str_t *value = cf->args->elts;
+  ngx_mrb_code_t *code = ngx_stream_mruby_mrb_code_from_file(cf->pool, &value[1]);
+
+  if (code == NGX_CONF_UNSET_PTR)
+    return NGX_CONF_ERROR;
+
+  rc = ngx_stream_mruby_shared_state_compile(cf, mmcf->mrb, code);
+  mmcf->init_code = code;
+
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
+
+  return NGX_CONF_OK;
+}
+
+static char *ngx_stream_mruby_init_build_code(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+  ngx_int_t rc;
+  ngx_stream_mruby_main_conf_t *mmcf = conf;
+  ngx_str_t *value = cf->args->elts;
+  ngx_mrb_code_t *code = ngx_stream_mruby_mrb_code_from_string(cf->pool, &value[1]);
+
+  if (code == NGX_CONF_UNSET_PTR)
+    return NGX_CONF_ERROR;
+
+  rc = ngx_stream_mruby_shared_state_compile(cf, mmcf->mrb, code);
+  mmcf->init_code = code;
+
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);
+    return NGX_CONF_ERROR;
+  }
+
+  return NGX_CONF_OK;
+}
+
 /* set directive values from file*/
 static char *ngx_stream_mruby_build_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
@@ -259,45 +400,42 @@ static char *ngx_stream_mruby_build_code(ngx_conf_t *cf, ngx_command_t *cmd, voi
   return NGX_CONF_OK;
 }
 
-/* create directive template */
-static void *ngx_stream_mruby_create_srv_conf(ngx_conf_t *cf)
+/*
+static void ngx_stream_mrb_raise_conf_error(mrb_state *mrb, mrb_value obj, ngx_conf_t *cf)
 {
-  ngx_stream_mruby_srv_conf_t *conf;
+  struct RString *str;
+  char *err_out;
 
-  conf = ngx_pcalloc(cf->pool, sizeof(ngx_stream_mruby_srv_conf_t));
-  if (conf == NULL) {
-    return NULL;
+  obj = mrb_funcall(mrb, obj, "inspect", 0);
+  if (mrb_type(obj) == MRB_TT_STRING) {
+    str = mrb_str_ptr(obj);
+    err_out = str->as.heap.ptr;
+    ngx_conf_log_error(NGX_LOG_ERR, cf, 0, "mrb_run failed. error: %s", err_out);
   }
-  conf->code = NGX_CONF_UNSET_PTR;
-  conf->mrb = mrb_open();
-  ngx_stream_mrb_class_init(conf->mrb);
-
-  return conf;
 }
 
-/* merge directive configuration */
-static char *ngx_stream_mruby_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
+static ngx_int_t ngx_stream_mrb_run_conf(ngx_conf_t *cf, mrb_state *mrb, ngx_mrb_code_t *code)
 {
-  ngx_stream_mruby_srv_conf_t *prev = parent;
-  ngx_stream_mruby_srv_conf_t *conf = child;
+  int ai = mrb_gc_arena_save(mrb);
 
-  if (conf->mrb == NULL) {
-    conf->mrb = prev->mrb;
+  ngx_log_error(NGX_LOG_INFO, cf->log, 0, "%s INFO %s:%d: mrb_run", MODULE_NAME, __func__, __LINE__);
+  mrb_run(mrb, code->proc, mrb_top_self(mrb));
+  if (mrb->exc) {
+    ngx_stream_mrb_raise_conf_error(mrb, mrb_obj_value(mrb->exc), cf);
+    mrb_gc_arena_restore(mrb, ai);
+    return NGX_ERROR;
   }
 
-  if (conf->code == NGX_CONF_UNSET_PTR) {
-    conf->code = prev->code;
-  }
-
-  return NGX_CONF_OK;
+  mrb_gc_arena_restore(mrb, ai);
+  return NGX_OK;
 }
+*/
 
 /* set mruby_handler to access phase */
 static ngx_int_t ngx_stream_mruby_init(ngx_conf_t *cf)
 {
-  ngx_stream_core_main_conf_t *cmcf;
+  ngx_stream_core_main_conf_t *cmcf = ngx_stream_conf_get_module_main_conf(cf, ngx_stream_core_module);
 
-  cmcf = ngx_stream_conf_get_module_main_conf(cf, ngx_stream_core_module);
   cmcf->access_handler = ngx_stream_mruby_handler;
 
   return NGX_OK;

--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -150,16 +150,16 @@ static char *ngx_stream_mruby_init_main_conf(ngx_conf_t *cf, void *conf)
 /* create directive template */
 static void *ngx_stream_mruby_create_srv_conf(ngx_conf_t *cf)
 {
-  ngx_stream_mruby_srv_conf_t *ascf;
+  ngx_stream_mruby_srv_conf_t *mscf;
 
-  ascf = ngx_pcalloc(cf->pool, sizeof(ngx_stream_mruby_srv_conf_t));
-  if (ascf == NULL) {
+  mscf = ngx_pcalloc(cf->pool, sizeof(ngx_stream_mruby_srv_conf_t));
+  if (mscf == NULL) {
     return NULL;
   }
 
-  ascf->code = NGX_CONF_UNSET_PTR;
+  mscf->code = NGX_CONF_UNSET_PTR;
 
-  return ascf;
+  return mscf;
 }
 
 /* merge directive configuration */
@@ -234,12 +234,12 @@ static void ngx_stream_mrb_state_clean(mrb_state *mrb)
 
 static ngx_int_t ngx_stream_mruby_handler(ngx_stream_session_t *s)
 {
-  ngx_stream_mruby_srv_conf_t *ascf = ngx_stream_get_module_srv_conf(s, ngx_stream_mruby_module);
+  ngx_stream_mruby_srv_conf_t *mscf = ngx_stream_get_module_srv_conf(s, ngx_stream_mruby_module);
   mrb_state *mrb = ngx_stream_mrb_state(s);
   mrb_int ai = mrb_gc_arena_save(mrb);
 
   mrb->ud = s;
-  mrb_run(mrb, ascf->code->proc, mrb_top_self(mrb));
+  mrb_run(mrb, mscf->code->proc, mrb_top_self(mrb));
 
   if (mrb->exc) {
     ngx_stream_mruby_raise_error(mrb, mrb_obj_value(mrb->exc), s);
@@ -385,7 +385,7 @@ static char *ngx_stream_mruby_init_build_code(ngx_conf_t *cf, ngx_command_t *cmd
 static char *ngx_stream_mruby_build_file(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
   mrb_state *mrb = ngx_stream_mrb_state_conf(cf);
-  ngx_stream_mruby_srv_conf_t *ascf = conf;
+  ngx_stream_mruby_srv_conf_t *mscf = conf;
   ngx_str_t *value;
   ngx_mrb_code_t *code;
   ngx_int_t rc;
@@ -399,7 +399,7 @@ static char *ngx_stream_mruby_build_file(ngx_conf_t *cf, ngx_command_t *cmd, voi
 
   rc = ngx_stream_mruby_shared_state_compile(cf, mrb, code);
 
-  ascf->code = code;
+  mscf->code = code;
 
   if (rc != NGX_OK) {
     ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);
@@ -413,7 +413,7 @@ static char *ngx_stream_mruby_build_file(ngx_conf_t *cf, ngx_command_t *cmd, voi
 static char *ngx_stream_mruby_build_code(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {
   mrb_state *mrb = ngx_stream_mrb_state_conf(cf);
-  ngx_stream_mruby_srv_conf_t *ascf = conf;
+  ngx_stream_mruby_srv_conf_t *mscf = conf;
   ngx_str_t *value;
   ngx_mrb_code_t *code;
   ngx_int_t rc;
@@ -427,7 +427,7 @@ static char *ngx_stream_mruby_build_code(ngx_conf_t *cf, ngx_command_t *cmd, voi
 
   rc = ngx_stream_mruby_shared_state_compile(cf, mrb, code);
 
-  ascf->code = code;
+  mscf->code = code;
 
   if (rc != NGX_OK) {
     ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "mrb_string(%s) load failed", value[1].data);

--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -46,11 +46,11 @@ static ngx_int_t ngx_stream_mruby_init(ngx_conf_t *cf);
 
 static ngx_command_t ngx_stream_mruby_commands[] = {
 
-    {ngx_string("mruby_stream_init"), NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1,
-     ngx_stream_mruby_init_build_file, NGX_STREAM_SRV_CONF_OFFSET, 0, NULL},
+    {ngx_string("mruby_stream_init"), NGX_STREAM_MAIN_CONF | NGX_CONF_TAKE1,
+     ngx_stream_mruby_init_build_file, NGX_STREAM_MAIN_CONF_OFFSET, 0, NULL},
 
-    {ngx_string("mruby_stream_init_code"), NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1,
-     ngx_stream_mruby_init_build_code, NGX_STREAM_SRV_CONF_OFFSET, 0, NULL},
+    {ngx_string("mruby_stream_init_code"), NGX_STREAM_MAIN_CONF | NGX_CONF_TAKE1,
+     ngx_stream_mruby_init_build_code, NGX_STREAM_MAIN_CONF_OFFSET, 0, NULL},
 
     {ngx_string("mruby_stream"), NGX_STREAM_MAIN_CONF | NGX_STREAM_SRV_CONF | NGX_CONF_TAKE1,
      ngx_stream_mruby_build_file, NGX_STREAM_SRV_CONF_OFFSET, 0, NULL},
@@ -93,6 +93,8 @@ static void *ngx_stream_mruby_create_main_conf(ngx_conf_t *cf)
 
   mmcf->init_code = NGX_CONF_UNSET_PTR;
   mmcf->mrb = mrb_open();
+  if (mmcf->mrb == NULL)
+    return NULL;
   ngx_stream_mrb_class_init(mmcf->mrb);
 
   return mmcf;
@@ -100,11 +102,6 @@ static void *ngx_stream_mruby_create_main_conf(ngx_conf_t *cf)
 
 static char *ngx_stream_mruby_init_main_conf(ngx_conf_t *cf, void *conf)
 {
-  // ngx_stream_mruby_srv_conf_t *mscf = ngx_stream_conf_get_module_srv_conf(cf, ngx_stream_mruby_module);
-  // ngx_stream_mruby_main_conf_t *mmcf = conf;
-
-  // mmcf->mrb = mscf->mrb;
-
   return NGX_CONF_OK;
 }
 
@@ -119,6 +116,8 @@ static void *ngx_stream_mruby_create_srv_conf(ngx_conf_t *cf)
   }
   ascf->code = NGX_CONF_UNSET_PTR;
   ascf->mrb = mrb_open();
+  if (ascf->mrb == NULL)
+    return NULL;
   ngx_stream_mrb_class_init(ascf->mrb);
 
   return ascf;

--- a/src/stream/ngx_stream_mruby_module.h
+++ b/src/stream/ngx_stream_mruby_module.h
@@ -16,4 +16,30 @@
 
 extern ngx_module_t ngx_stream_mruby_module;
 
+typedef enum code_type_t { NGX_MRB_CODE_TYPE_FILE, NGX_MRB_CODE_TYPE_STRING } code_type_t;
+
+typedef struct ngx_mrb_code_t {
+  union code {
+    char *file;
+    char *string;
+  } code;
+  code_type_t code_type;
+  struct RProc *proc;
+  mrbc_context *ctx;
+} ngx_mrb_code_t;
+
+typedef struct {
+
+  mrb_state *mrb;
+  ngx_mrb_code_t *init_code;
+
+} ngx_stream_mruby_main_conf_t;
+
+typedef struct {
+
+  mrb_state *mrb;
+  ngx_mrb_code_t *code;
+
+} ngx_stream_mruby_srv_conf_t;
+
 #endif // NGX_STREAM_MRUBY_MODULE_H

--- a/src/stream/ngx_stream_mruby_module.h
+++ b/src/stream/ngx_stream_mruby_module.h
@@ -16,30 +16,4 @@
 
 extern ngx_module_t ngx_stream_mruby_module;
 
-typedef enum code_type_t { NGX_MRB_CODE_TYPE_FILE, NGX_MRB_CODE_TYPE_STRING } code_type_t;
-
-typedef struct ngx_mrb_code_t {
-  union code {
-    char *file;
-    char *string;
-  } code;
-  code_type_t code_type;
-  struct RProc *proc;
-  mrbc_context *ctx;
-} ngx_mrb_code_t;
-
-typedef struct {
-
-  mrb_state *mrb;
-  ngx_mrb_code_t *init_code;
-
-} ngx_stream_mruby_main_conf_t;
-
-typedef struct {
-
-  mrb_state *mrb;
-  ngx_mrb_code_t *code;
-
-} ngx_stream_mruby_srv_conf_t;
-
 #endif // NGX_STREAM_MRUBY_MODULE_H

--- a/src/stream/ngx_stream_mruby_module.h
+++ b/src/stream/ngx_stream_mruby_module.h
@@ -16,4 +16,9 @@
 
 extern ngx_module_t ngx_stream_mruby_module;
 
+typedef struct {
+  ngx_stream_session_t *s;
+  ngx_int_t stream_status;
+} ngx_stream_mruby_internal_ctx_t;
+
 #endif // NGX_STREAM_MRUBY_MODULE_H

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -14,7 +14,7 @@ stream {
       listen 12346;
       mruby_stream_code '
         c = Nginx::Stream::Connection.new "dynamic_server0"
-        #c.upstream_server = "127.0.0.1:58081"
+        # get from mruby_stream_init
         c.upstream_server = Userdata.new.new_upstream
         Nginx::Stream.log Nginx::Stream::LOG_NOTICE, "mruby_stream"
       ';

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -6,11 +6,16 @@ stream {
     server 127.0.0.1:58081;
   }
 
+  mruby_stream_init_code '
+    Userdata.new.new_upstream = "127.0.0.1:58081"
+  ';
+
   server {
       listen 12346;
       mruby_stream_code '
         c = Nginx::Stream::Connection.new "dynamic_server0"
         c.upstream_server = "127.0.0.1:58081"
+        #c.upstream_server = Userdata.new.new_upstream
       ';
       proxy_pass dynamic_server0;
   }

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -15,6 +15,10 @@ stream {
     p "ngx_mruby: STREAM: mruby_stream_init_worker_code"
   ';
 
+  mruby_stream_exit_worker_code '
+    p "ngx_mruby: STREAM: mruby_stream_exit_worker_code"
+  ';
+
   server {
       listen 12346;
       mruby_stream_code '

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -14,8 +14,9 @@ stream {
       listen 12346;
       mruby_stream_code '
         c = Nginx::Stream::Connection.new "dynamic_server0"
-        c.upstream_server = "127.0.0.1:58081"
-        #c.upstream_server = Userdata.new.new_upstream
+        #c.upstream_server = "127.0.0.1:58081"
+        c.upstream_server = Userdata.new.new_upstream
+        Nginx::Stream.log Nginx::Stream::LOG_NOTICE, "mruby_stream"
       ';
       proxy_pass dynamic_server0;
   }

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -38,5 +38,16 @@ stream {
       mruby_stream build/nginx/html/stream_lb.rb;
       proxy_pass dynamic_server1;
   }
+  server {
+      listen 12347;
+      mruby_stream_code '
+        if Nginx::Stream::Connection.remote_ip == "127.0.0.1"
+          current_status = Nginx::Stream::Connection.stream_status
+          Nginx::Stream::Connection.stream_status = Nginx::Stream::ABORT
+          Nginx::Stream.log Nginx::Stream::LOG_NOTICE, "current status=#{(current_status == Nginx::Stream::DECLINED) ? "NGX_DECLINED" : current_status} but deny from #{Nginx::Stream::Connection.remote_ip} return NGX_ABORT"
+        end
+      ';
+      proxy_pass dynamic_server1;
+  }
 }
 

--- a/test/conf/nginx.stream.conf
+++ b/test/conf/nginx.stream.conf
@@ -7,7 +7,12 @@ stream {
   }
 
   mruby_stream_init_code '
+    p "ngx_mruby: STREAM: mruby_stream_init_code"
     Userdata.new.new_upstream = "127.0.0.1:58081"
+  ';
+
+  mruby_stream_init_worker_code '
+    p "ngx_mruby: STREAM: mruby_stream_init_worker_code"
   ';
 
   server {


### PR DESCRIPTION
- [x] shared mruby state between init and session phase
- [x] add init directive
- [x] add worker init directive 
- [x] add worker exit directive
- [x] support mruby internal context like stream status or stream_sessiont
- [x] add the control methods for nginx stream status

### example

- `nginx.conf`

```nginx
stream {
  upstream dynamic_server0 {
    server 127.0.0.1:58080;
  }
  upstream dynamic_server1 {
    server 127.0.0.1:58081;
  }

  mruby_stream_init_code '
    Userdata.new.new_upstream = "127.0.0.1:58081"
  ';

  mruby_stream_init_worker_code '
    p "ngx_mruby: STREAM: mruby_stream_init_worker_code"
  ';

  mruby_stream_exit_worker_code '
    p "ngx_mruby: STREAM: mruby_stream_exit_worker_code"
  ';

  server {
    listen 12346;
    mruby_stream_code '
      # get from mruby_stream_init
      Nginx::Stream::Connection.new("dynamic_server0").upstream_server = Userdata.new.new_upstream
    ';
    proxy_pass dynamic_server0;
  }

  server {
    listen 12345;
    # code cached only
    mruby_stream build/nginx/html/stream_lb.rb;
    proxy_pass dynamic_server1;
  }

  server {
    listen 12347;
    mruby_stream_code '
      if Nginx::Stream::Connection.remote_ip == "127.0.0.1"
        current_status = Nginx::Stream::Connection.stream_status
        Nginx::Stream::Connection.stream_status = Nginx::Stream::ABORT
        Nginx::Stream.log Nginx::Stream::LOG_NOTICE, "current status=#{(current_status == Nginx::Stream::DECLINED) ? "NGX_DECLINED" : current_status} but deny from #{Nginx::Stream::Connection.remote_ip} return NGX_ABORT"
      end
    ';
    proxy_pass dynamic_server1;
  }
}
```

- `build/nginx/html/stream_lb.rb`

```ruby
c = Nginx::Stream::Connection.new "dynamic_server1"
c.upstream_server = "127.0.0.1:58080"
```