### PR TITLE
Support ssl_handshake handler and dynamic certificate change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ compiler:
 before_install:
     - sudo apt-get -qq update
 install:
-    - sudo apt-get -qq install rake bison libcurl4-openssl-dev
+    - sudo apt-get -qq install rake bison libcurl4-openssl-dev libssl-dev
 env:
   - NGINX_SRC_MAJOR=1
     NGINX_SRC_MINOR=4

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ compiler:
   - gcc
   - clang
 before_install:
-    - sudo apt-get -qq update
+  - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+  - sudo apt-get -qq update
 install:
-    - sudo apt-get -qq install rake bison libcurl4-openssl-dev libssl-dev
+  - sudo apt-get -qq install rake bison git gperf g++-4.9 libstdc++-4.9-dev libev-dev libevent-dev libjansson-dev libjemalloc-dev libxml2-dev libssl-dev zlib1g-dev
 env:
   - NGINX_SRC_MAJOR=1
     NGINX_SRC_MINOR=4

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
   - sudo apt-get -qq update
 install:
-  - sudo apt-get -qq install rake bison git gperf g++-4.9 libstdc++-4.9-dev libev-dev libevent-dev libjansson-dev libjemalloc-dev libxml2-dev libssl-dev zlib1g-dev
+  - sudo apt-get -qq install rake bison git gperf libssl-dev
 env:
   - NGINX_SRC_MAJOR=1
     NGINX_SRC_MINOR=4
@@ -27,17 +27,3 @@ script:
   - echo "NGINX_SRC_PATCH=${NGINX_SRC_PATCH}" >> nginx_version
   - echo "NGINX_SRC_VER=nginx-${NGINX_SRC_MAJOR}.${NGINX_SRC_MINOR}.${NGINX_SRC_PATCH}" >> nginx_version
   - sh test.sh
-notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#hosting-ja"
-    on_success: always
-    on_failure: always
-    use_notice: true
-    skip_join: true
-    template:
-        - "[%{message}] %{repository} (%{commit}) by %{author}: See %{build_url}"
-  webhooks:
-    - secure: "aGWGYK++jT3o4ENZ4NzkyCHBn1f8eyqXEa7dEph+088qQlnnieqDn3xzlmBA1hiqouZ6ioTICSfYUaXk6h4zte1SX0nR2rO/XJYhseTqaiqgx+1cqw9aWEkwsAYu0oDuND5pMAa2so3zn38UuHLKvOMNEhi/xRXMFx3Bl5P8Pxk="
-
-

--- a/Makefile.in
+++ b/Makefile.in
@@ -24,8 +24,8 @@ else
 endif
 
 #   flags
-CFLAGS = $(MRUBY_CFLAGS)
-LDFLAGS = $(MRUBY_LDFLAGS)
+CFLAGS = $(MRUBY_CFLAGS) -I/usr/local/include
+LDFLAGS = $(MRUBY_LDFLAGS) -L/usr/local/lib
 LIBS = $(MRUBY_LIBS) $(MRUBY_LDFLAGS_BEFORE_LIBS) $(MRUBY_ROOT)/build/host/lib/libmruby.a
 
 #   the default target

--- a/config
+++ b/config
@@ -15,6 +15,7 @@ NGX_ADDON_SRCS="$NGX_ADDON_SRCS \
                 $ngx_addon_dir/src/http/ngx_http_mruby_server.c \
                 $ngx_addon_dir/src/http/ngx_http_mruby_filter.c \
                 $ngx_addon_dir/src/http/ngx_http_mruby_upstream.c \
+                $ngx_addon_dir/src/http/ngx_http_mruby_ssl.c \
                 "
 if [ $STREAM = YES ]; then
   HTTP_FILTER_MODULES="$HTTP_FILTER_MODULES ngx_stream_mruby_module"

--- a/src/http/ngx_http_mruby_init.c
+++ b/src/http/ngx_http_mruby_init.c
@@ -26,6 +26,7 @@ void ngx_mrb_filter_class_init(mrb_state *mrb, struct RClass *calss);
 #ifdef NGX_USE_MRUBY_UPSTREAM
 void ngx_mrb_upstream_class_init(mrb_state *mrb, struct RClass *calss);
 #endif
+void ngx_mrb_ssl_class_init(mrb_state *mrb, struct RClass *class);
 
 ngx_int_t ngx_mrb_class_init(mrb_state *mrb)
 {
@@ -49,6 +50,8 @@ ngx_int_t ngx_mrb_class_init(mrb_state *mrb)
   ngx_mrb_upstream_class_init(mrb, class);
   GC_ARENA_RESTORE;
 #endif
+  ngx_mrb_ssl_class_init(mrb, class);
+  GC_ARENA_RESTORE;
 
   return NGX_OK;
 }

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -2012,7 +2012,8 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
     return 1;
   }
 
-  ngx_log_error(NGX_LOG_DEBUG, c->log, 0, "mruby ssl handler: changing certficate to cert=%V key=%V", &mscf->cert_path, &mscf->cert_key_path);
+  ngx_log_error(NGX_LOG_DEBUG, c->log, 0, "mruby ssl handler: changing certficate to cert=%V key=%V", &mscf->cert_path,
+                &mscf->cert_key_path);
   ngx_http_mruby_set_der_certificate(ssl_conn, &mscf->cert_path, &mscf->cert_key_path);
   return 1;
 }

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -1979,6 +1979,7 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
     return 1;
   }
 
+  mscf->servername = &host;
   mrb = mscf->state->mrb;
   mrb->ud = mscf;
   ai = mrb_gc_arena_save(mrb);

--- a/src/http/ngx_http_mruby_module.h
+++ b/src/http/ngx_http_mruby_module.h
@@ -52,6 +52,13 @@ typedef struct {
 
 extern ngx_module_t ngx_http_mruby_module;
 
+typedef struct {
+  ngx_mrb_state_t *state;
+  ngx_mrb_code_t *ssl_handshake_code;
+  ngx_str_t cert_path;
+  ngx_str_t cert_key_path;
+} ngx_http_mruby_srv_conf_t;
+
 typedef struct ngx_http_mruby_main_conf_t {
   ngx_mrb_state_t *state;
   ngx_mrb_code_t *init_code;

--- a/src/http/ngx_http_mruby_module.h
+++ b/src/http/ngx_http_mruby_module.h
@@ -55,6 +55,7 @@ extern ngx_module_t ngx_http_mruby_module;
 typedef struct {
   ngx_mrb_state_t *state;
   ngx_mrb_code_t *ssl_handshake_code;
+  ngx_str_t *servername;
   ngx_str_t cert_path;
   ngx_str_t cert_key_path;
 } ngx_http_mruby_srv_conf_t;

--- a/src/http/ngx_http_mruby_ssl.c
+++ b/src/http/ngx_http_mruby_ssl.c
@@ -18,7 +18,7 @@ static mrb_value ngx_mrb_ssl_set_cert(mrb_state *mrb, mrb_value self)
 {
   ngx_http_mruby_srv_conf_t *mscf = mrb->ud;
   char *path;
-  size_t path_len;
+  mrb_int path_len;
 
   mrb_get_args(mrb, "s", &path, &path_len);
   mscf->cert_path.data = (u_char *)path;
@@ -31,7 +31,7 @@ static mrb_value ngx_mrb_ssl_set_cert_key(mrb_state *mrb, mrb_value self)
 {
   ngx_http_mruby_srv_conf_t *mscf = mrb->ud;
   char *path;
-  size_t path_len;
+  mrb_int path_len;
 
   mrb_get_args(mrb, "s", &path, &path_len);
   mscf->cert_key_path.data = (u_char *)path;

--- a/src/http/ngx_http_mruby_ssl.c
+++ b/src/http/ngx_http_mruby_ssl.c
@@ -4,6 +4,7 @@
 // See Copyright Notice in ngx_http_mruby_module.c
 */
 
+#include "ngx_http_mruby_module.h"
 #include "ngx_http_mruby_ssl.h"
 
 #include <mruby.h>
@@ -15,12 +16,28 @@
 
 static mrb_value ngx_mrb_ssl_set_cert(mrb_state *mrb, mrb_value self)
 {
-  return self;
+  ngx_http_mruby_srv_conf_t *mscf = mrb->ud;
+  char *path;
+  size_t path_len;
+
+  mrb_get_args(mrb, "s", &path, &path_len);
+  mscf->cert_path.data = (u_char *)path;
+  mscf->cert_path.len = path_len;
+
+  return mrb_str_new(mrb, (char *)mscf->cert_path.data, mscf->cert_path.len);
 }
 
 static mrb_value ngx_mrb_ssl_set_cert_key(mrb_state *mrb, mrb_value self)
 {
-  return self;
+  ngx_http_mruby_srv_conf_t *mscf = mrb->ud;
+  char *path;
+  size_t path_len;
+
+  mrb_get_args(mrb, "s", &path, &path_len);
+  mscf->cert_key_path.data = (u_char *)path;
+  mscf->cert_key_path.len = path_len;
+
+  return mrb_str_new(mrb, (char *)mscf->cert_key_path.data, mscf->cert_key_path.len);
 }
 
 void ngx_mrb_ssl_class_init(mrb_state *mrb, struct RClass *class)

--- a/src/http/ngx_http_mruby_ssl.c
+++ b/src/http/ngx_http_mruby_ssl.c
@@ -1,0 +1,33 @@
+/*
+// ngx_http_mruby_ssl.c - ngx_mruby mruby module
+//
+// See Copyright Notice in ngx_http_mruby_module.c
+*/
+
+#include "ngx_http_mruby_ssl.h"
+
+#include <mruby.h>
+#include <mruby/proc.h>
+#include <mruby/data.h>
+#include <mruby/compile.h>
+#include <mruby/string.h>
+#include <mruby/class.h>
+
+static mrb_value ngx_mrb_ssl_set_cert(mrb_state *mrb, mrb_value self)
+{
+  return self;
+}
+
+static mrb_value ngx_mrb_ssl_set_cert_key(mrb_state *mrb, mrb_value self)
+{
+  return self;
+}
+
+void ngx_mrb_ssl_class_init(mrb_state *mrb, struct RClass *class)
+{
+  struct RClass *class_ssl;
+
+  class_ssl = mrb_define_class_under(mrb, class, "SSL", mrb->object_class);
+  mrb_define_method(mrb, class_ssl, "certificate=", ngx_mrb_ssl_set_cert, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, class_ssl, "certificate_key=", ngx_mrb_ssl_set_cert_key, MRB_ARGS_REQ(1));
+}

--- a/src/http/ngx_http_mruby_ssl.c
+++ b/src/http/ngx_http_mruby_ssl.c
@@ -14,6 +14,13 @@
 #include <mruby/string.h>
 #include <mruby/class.h>
 
+static mrb_value ngx_mrb_ssl_get_servername(mrb_state *mrb, mrb_value self)
+{
+  ngx_http_mruby_srv_conf_t *mscf = mrb->ud;
+
+  return mrb_str_new(mrb, (char *)mscf->servername->data, mscf->servername->len);
+}
+
 static mrb_value ngx_mrb_ssl_set_cert(mrb_state *mrb, mrb_value self)
 {
   ngx_http_mruby_srv_conf_t *mscf = mrb->ud;
@@ -45,6 +52,7 @@ void ngx_mrb_ssl_class_init(mrb_state *mrb, struct RClass *class)
   struct RClass *class_ssl;
 
   class_ssl = mrb_define_class_under(mrb, class, "SSL", mrb->object_class);
+  mrb_define_method(mrb, class_ssl, "servername", ngx_mrb_ssl_get_servername, MRB_ARGS_NONE());
   mrb_define_method(mrb, class_ssl, "certificate=", ngx_mrb_ssl_set_cert, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, class_ssl, "certificate_key=", ngx_mrb_ssl_set_cert_key, MRB_ARGS_REQ(1));
 }

--- a/src/http/ngx_http_mruby_ssl.h
+++ b/src/http/ngx_http_mruby_ssl.h
@@ -1,0 +1,15 @@
+/*
+// ngx_http_mruby_connection.h - ngx_mruby mruby module header
+//
+// See Copyright Notice in ngx_http_mruby_module.c
+*/
+
+#ifndef NGX_HTTP_MRUBY_CONNECTION_H
+#define NGX_HTTP_MRUBY_CONNECTION_H
+
+#include <ngx_http.h>
+#include <mruby.h>
+#include <mruby/hash.h>
+#include <mruby/variable.h>
+
+#endif // NGX_HTTP_MRUBY_CONNECTION_H

--- a/src/stream/ngx_stream_mruby_connection.c
+++ b/src/stream/ngx_stream_mruby_connection.c
@@ -157,7 +157,8 @@ static mrb_value ngx_stream_mrb_proxy_protocol_addr(mrb_state *mrb, mrb_value se
   ngx_stream_mruby_internal_ctx_t *ictx = mrb->ud;
   ngx_stream_session_t *s = ictx->s;
 
-  return mrb_str_new(mrb, (const char *)s->connection->proxy_protocol_addr.data, s->connection->proxy_protocol_addr.len);
+  return mrb_str_new(mrb, (const char *)s->connection->proxy_protocol_addr.data,
+                     s->connection->proxy_protocol_addr.len);
 }
 
 void ngx_stream_mrb_conn_class_init(mrb_state *mrb, struct RClass *class)

--- a/test.sh
+++ b/test.sh
@@ -81,7 +81,7 @@ echo "ngx_mruby testing ..."
 make install
 ps -C nginx && killall nginx
 sed -e "s|__NGXDOCROOT__|${NGINX_INSTALL_DIR}/html/|g" test/conf/nginx.conf > ${NGINX_INSTALL_DIR}/conf/nginx.conf
-cd ${NGINX_INSTALL_DIR}/html && sh -c 'yes "" | openssl req -new -days 365 -x509 -nodes -keyout server.key -out server.crt' && sh -c 'yes "" | openssl req -new -days 1 -x509 -nodes -keyout dummy.key -out dummy.crt' && cd -
+cd ${NGINX_INSTALL_DIR}/html && sh -c 'yes "" | openssl req -new -days 365 -x509 -nodes -keyout localhost.key -out localhost.crt' && sh -c 'yes "" | openssl req -new -days 1 -x509 -nodes -keyout dummy.key -out dummy.crt' && cd -
 
 if [ $NGINX_SRC_MINOR -ge 9 ]; then
   if [ $NGINX_SRC_PATCH -ge 6 ]; then

--- a/test.sh
+++ b/test.sh
@@ -10,15 +10,16 @@ set -e
 . ./nginx_version
 
 NGINX_INSTALL_DIR=`pwd`'/build/nginx'
+NGINX_DEFUALT_OPT='--with-http_stub_status_module --with-http_ssl_module'
 
 if [ $NGINX_SRC_MINOR -ge 9 ]; then
   if [ $NGINX_SRC_PATCH -ge 6 ]; then
-    NGINX_CONFIG_OPT="--prefix=${NGINX_INSTALL_DIR} --with-http_stub_status_module --with-stream --without-stream_access_module"
+    NGINX_CONFIG_OPT="--prefix=${NGINX_INSTALL_DIR} ${NGINX_DEFUALT_OPT} --with-stream --without-stream_access_module"
   else
-  NGINX_CONFIG_OPT="--prefix=${NGINX_INSTALL_DIR} --with-http_stub_status_module"
+  NGINX_CONFIG_OPT="--prefix=${NGINX_INSTALL_DIR} ${NGINX_DEFUALT_OPT}"
   fi
 else
-  NGINX_CONFIG_OPT="--prefix=${NGINX_INSTALL_DIR} --with-http_stub_status_module"
+  NGINX_CONFIG_OPT="--prefix=${NGINX_INSTALL_DIR} ${NGINX_DEFUALT_OPT}"
 fi
 
 if [ "$NUM_THREADS_ENV" != "" ]; then

--- a/test.sh
+++ b/test.sh
@@ -81,6 +81,7 @@ echo "ngx_mruby testing ..."
 make install
 ps -C nginx && killall nginx
 sed -e "s|__NGXDOCROOT__|${NGINX_INSTALL_DIR}/html/|g" test/conf/nginx.conf > ${NGINX_INSTALL_DIR}/conf/nginx.conf
+cd ${NGINX_INSTALL_DIR}/html && sh -c 'yes "" | openssl req -new -days 365 -x509 -nodes -keyout server.key -out server.crt' && sh -c 'yes "" | openssl req -new -days 1 -x509 -nodes -keyout dummy.key -out dummy.crt' && cd -
 
 if [ $NGINX_SRC_MINOR -ge 9 ]; then
   if [ $NGINX_SRC_PATCH -ge 6 ]; then

--- a/test/build_config.rb
+++ b/test/build_config.rb
@@ -19,6 +19,7 @@ MRuby::Build.new do |conf|
   # conf.gem :github => 'masuidrive/mrbgems-example', :branch => 'master'
   # conf.gem :git => 'git@github.com:masuidrive/mrbgems-example.git', :branch => 'master', :options => '-v'
 
+  conf.gem :mgem => "mruby-polarssl"
   conf.gem :github => 'matsumoto-r/mruby-simplehttp'
   conf.gem :github => 'matsumoto-r/mruby-httprequest'
   conf.gem :github => 'matsumoto-r/mruby-uname'

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -40,7 +40,7 @@ http {
         ';
 
         location / {
-            mruby_content_handler_code "Nginx.rputs 'proxy test ok'";
+            mruby_content_handler_code "Nginx.rputs 'ssl test ok'";
         }
     }
 

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -26,6 +26,25 @@ http {
     mruby_exit_worker_code 'p "[#{Process.pid}] exit worker process from inline code"';
 
     server {
+        listen       58082 ssl;
+        server_name  localhost;
+        ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+        ssl_certificate     __NGXDOCROOT__/dummy.crt;
+        ssl_certificate_key __NGXDOCROOT__/dummy.key;
+
+        mruby_ssl_handshake_handler_code '
+          ssl = Nginx::SSL.new
+          ssl.certificate = "__NGXDOCROOT__/server.crt"
+          ssl.certificate_key = "__NGXDOCROOT__/server.key"
+        ';
+
+        location / {
+            mruby_content_handler_code "Nginx.rputs 'proxy test ok'";
+        }
+    }
+
+    server {
         listen       58081;
         server_name  localhost;
 

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -35,8 +35,8 @@ http {
 
         mruby_ssl_handshake_handler_code '
           ssl = Nginx::SSL.new
-          ssl.certificate = "__NGXDOCROOT__/server.crt"
-          ssl.certificate_key = "__NGXDOCROOT__/server.key"
+          ssl.certificate = "__NGXDOCROOT__/#{ssl.servername}.crt"
+          ssl.certificate_key = "__NGXDOCROOT__/#{ssl.servername}.key"
         ';
 
         location / {

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -27,7 +27,7 @@ http {
 
     server {
         listen       58082 ssl;
-        server_name  localhost;
+        server_name  _;
         ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers         HIGH:!aNULL:!MD5;
         ssl_certificate     __NGXDOCROOT__/dummy.crt;

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -10,6 +10,10 @@ def base
   "http://#{http_host}"
 end
 
+def base_ssl
+  "https://127.0.0.1:58082"
+end
+
 t = SimpleTest.new "ngx_mruby test"
 
 nginx_version = HttpRequest.new.get(base + '/nginx-version')["body"]
@@ -334,6 +338,11 @@ t.assert('ngx_mruby - multipul response headers', 'location /multi_headers_out')
   t.assert_equal 200, res.code
   t.assert_equal '["fuga", "foo"]', res["body"]
   t.assert_equal ["fuga", "foo"], res["hoge"]
+end
+
+t.assert('ngx_mruby - ssl certificate changing') do
+  res = HttpRequest.new.get(base_ssl + '/')
+  t.assert_equal 'ssl test ok', res["body"]
 end
 
 #

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -11,7 +11,7 @@ def base
 end
 
 def base_ssl
-  "https://127.0.0.1:58082"
+  "https://localhost:58082"
 end
 
 t = SimpleTest.new "ngx_mruby test"


### PR DESCRIPTION
- config

```nginx
    server {
        listen       58082 ssl;
        server_name  localhost;
        ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
        ssl_ciphers         HIGH:!aNULL:!MD5;
        # one day cert
        ssl_certificate     /Users/matsumoto_r/DEV/ngx_mruby/build/nginx/html//dummy.crt;
        ssl_certificate_key /Users/matsumoto_r/DEV/ngx_mruby/build/nginx/html//dummy.key;

        # 365 days cert
        mruby_ssl_handshake_handler_code '
          ssl = Nginx::SSL.new
          ssl.certificate = "/Users/matsumoto_r/DEV/ngx_mruby/build/nginx/html//server.crt"
          ssl.certificate_key = "/Users/matsumoto_r/DEV/ngx_mruby/build/nginx/html//server.key"
        ';

        location / {
            mruby_content_handler_code "Nginx.rputs 'ssl test ok'";
        }
    }
```

- normal ssl

```nginx
    server {
        listen       58082 ssl;
        server_name  localhost;
        ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
        ssl_ciphers         HIGH:!aNULL:!MD5;
        # one day cert
        ssl_certificate     /Users/matsumoto_r/DEV/ngx_mruby/build/nginx/html//dummy.crt;
        ssl_certificate_key /Users/matsumoto_r/DEV/ngx_mruby/build/nginx/html//dummy.key;

        location / {
            mruby_content_handler_code "Nginx.rputs 'ssl test ok'";
        }
    }
```

access via browser.

<img width="539" alt="2016-01-07 17 53 03" src="https://cloud.githubusercontent.com/assets/648437/12167289/ab9896ba-b56e-11e5-9869-4bb0f6295e57.png">

- dynamic certificate

```nginx
    server {
        listen       58082 ssl;
        server_name  localhost;
        ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
        ssl_ciphers         HIGH:!aNULL:!MD5;
        # one day cert
        ssl_certificate     /Users/matsumoto_r/DEV/ngx_mruby/build/nginx/html//dummy.crt;
        ssl_certificate_key /Users/matsumoto_r/DEV/ngx_mruby/build/nginx/html//dummy.key;

        # 365 days cert
        mruby_ssl_handshake_handler_code '
          ssl = Nginx::SSL.new
          ssl.certificate = "/Users/matsumoto_r/DEV/ngx_mruby/build/nginx/html//server.crt"
          ssl.certificate_key = "/Users/matsumoto_r/DEV/ngx_mruby/build/nginx/html//server.key"
        ';

        location / {
            mruby_content_handler_code "Nginx.rputs 'ssl test ok'";
        }
    }
```

access via browser

<img width="547" alt="2016-01-07 17 51 53" src="https://cloud.githubusercontent.com/assets/648437/12167291/b30d55ca-b56e-11e5-8fe8-4905a46e7195.png">
