### PR TITLE
Add dynamic certificate read error

### DIFF
--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -2039,12 +2039,12 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
   if (access((const char *)mscf->cert_path.data, F_OK | R_OK) != 0) {
     ngx_log_error(NGX_LOG_ERR, c->log, 0, MODULE_NAME " : mruby ssl handler: cert [%V] not exists or not read",
                   &mscf->cert_path);
-    return 1;
+    return 0;
   }
   if (access((const char *)mscf->cert_key_path.data, F_OK | R_OK) != 0) {
     ngx_log_error(NGX_LOG_ERR, c->log, 0, MODULE_NAME " : mruby ssl handler: cert_key [%V] not exists or not read",
                   &mscf->cert_key_path);
-    return 1;
+    return 0;
   }
 
   ngx_log_error(NGX_LOG_DEBUG, c->log, 0, MODULE_NAME " : mruby ssl handler: changing certficate to cert=%V key=%V",

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -345,6 +345,8 @@ t.assert('ngx_mruby - ssl certificate changing') do
   t.assert_equal 'ssl test ok', res
   res = `openssl s_client -servername localhost -connect localhost:58082 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not | sed -e "s/://" | awk '{print (res = $6 - res)}' | tail -n 1`.chomp
   t.assert_equal "1", res
+  res = `openssl s_client -servername hogehoge -connect 127.0.0.1:58082 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not`.chomp
+  t.assert_equal "", res
 end
 
 #


### PR DESCRIPTION
return tls handshake error when dynamic cert read was failed.

- command line

```
$  openssl s_client -servername matsumotory.foo -connect 127.0.0.1:58082 < /dev/null 2> /dev/null
CONNECTED(00000003)
---
no peer certificate available
---
No client certificate CA names sent
---
SSL handshake has read 7 bytes and written 342 bytes
---
New, (NONE), Cipher is (NONE)
Secure Renegotiation IS NOT supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
SSL-Session:
    Protocol  : TLSv1.2
    Cipher    : 0000
    Session-ID:
    Session-ID-ctx:
    Master-Key:
    Key-Arg   : None
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    Start Time: 1452851801
    Timeout   : 300 (sec)
    Verify return code: 0 (ok)
---
```

- error log

```
2016/01/15 19:01:47 [debug] 58613#0: *1 ngx_mruby : mruby ssl handler: servername "matsumotory.foo"
2016/01/15 19:01:47 [error] 58613#0: *1 ngx_mruby : mruby ssl handler: cert [/Users/matsumoto_r/DEV/ngx_mruby/build/nginx/html//matsumotory.foo.crt] not exists or not read while SSL handshaking, client: 127.0.0.1, server: 0.0.0.0:58082
2016/01/15 19:01:47 [crit] 58613#0: *1 SSL_do_handshake() failed (SSL: error:1408A179:SSL routines:ssl3_get_client_hello:cert cb error) while SSL handshaking, client: 127.0.0.1, server: 0.0.0.0:58082
```

- browser

<img width="467" alt="2016-01-15 18 54 42" src="https://cloud.githubusercontent.com/assets/648437/12350416/4197045c-bbba-11e5-8665-129a83e7bb64.png">
