### PR TITLE
Support development version of NGINX

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,6 +9,13 @@ RAKE=rake -j $(NUM_THREADS)
 NGX_MRUBY_ROOT=$(shell pwd)
 NGX_SRC_ROOT=@NGX_SRC_ROOT@
 NGX_CONFIG_OPT=@NGX_CONFIG_OPT@
+ifeq ($(wildcard $(NGX_SRC_ROOT)/auto/configure),)
+  NGX_CONFIGURE = ./configure
+else
+  # development branch does not have configure script in top of directory.
+  NGX_CONFIGURE = ./auto/configure
+endif
+
 MRUBY_ROOT=@MRUBY_ROOT@
 NDK_ROOT=@NDK_ROOT@
 
@@ -57,7 +64,7 @@ make_ngx_mruby:
 	cd $(NGX_SRC_ROOT) && $(MAKE)
 
 ngx_mruby: generate_gems_config
-	cd $(NGX_SRC_ROOT) && ./configure --add-module=$(NGX_MRUBY_ROOT) --add-module=$(NDK_ROOT) $(NGX_CONFIG_OPT) && $(MAKE)
+	cd $(NGX_SRC_ROOT) && $(NGX_CONFIGURE) --add-module=$(NGX_MRUBY_ROOT) --add-module=$(NDK_ROOT) $(NGX_CONFIG_OPT) && $(MAKE)
 
 #   create mrbgems config
 generate_gems_config:


### PR DESCRIPTION
Git repository of nginx has no `configure` script in top of directory. It location is under `auto` directory.

This changes make to work develop version of NGINX.