### PR TITLE
Added helper method for Nginx::Request instance

### DIFF
--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -14,7 +14,7 @@ class Nginx
     end
 
     def get_uri_args
-      Hash[*self.args.split("&").map{|arg| arg.split("=")}.flatten]
+      args_to_hash(self.args)
     end
 
     def set_uri_args(params)
@@ -23,7 +23,13 @@ class Nginx
     end
 
     def get_post_args
-      Hash[*self.body.split("&").map{|arg| arg.split("=")}.flatten]
+      args_to_hash(self.body)
+    end
+
+    private
+
+    def args_to_hash(args)
+      Hash[*args.split("&").map{|arg| arg.split("=")}.flatten]
     end
   end
 

--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -18,6 +18,7 @@ class Nginx
     end
 
     def set_uri_args(params)
+      raise ArgumentError unless params.is_a?(Hash)
       self.args = params.map{|k,v| "#{k}=#{v}"}.join("&")
     end
 

--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -14,6 +14,7 @@ class Nginx
       self.get_body
     end
   end
+
   class Headers_in
     def user_agent
       self["User-Agent"]

--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -3,12 +3,11 @@ class Nginx
     def scheme
       self.var.scheme
     end
+
     def document_root
       Nginx::Server.new.document_root
     end
-    #def document_root=(path)
-    #  Nginx::Var.new.set "document_root", path
-    #end
+
     def body
       self.read_body
       self.get_body

--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -19,6 +19,10 @@ class Nginx
       self["User-Agent"]
     end
   end
+
+  def self.var
+    Var.new
+  end
 end
 
 module Kernel

--- a/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
+++ b/mrbgems/ngx_mruby_mrblib/mrblib/mrb_nginx.rb
@@ -12,6 +12,18 @@ class Nginx
       self.read_body
       self.get_body
     end
+
+    def get_uri_args
+      Hash[*self.args.split("&").map{|arg| arg.split("=")}.flatten]
+    end
+
+    def set_uri_args(params)
+      self.args = params.map{|k,v| "#{k}=#{v}"}.join("&")
+    end
+
+    def get_post_args
+      Hash[*self.body.split("&").map{|arg| arg.split("=")}.flatten]
+    end
   end
 
   class Headers_in

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -503,6 +503,29 @@ http {
             Nginx::return 200
           ';
         }
+        location /get_uri_args {
+          mruby_content_handler_code '
+            args = Nginx::Request.new.get_uri_args
+            Nginx.echo args.map{|k, v| "#{k}:#{v}" }.join(\n)
+          ';
+        }
+        location /set_uri_args {
+          mruby_content_handler_code '
+            args = {"pass" => "ngx_mruby"}
+            r = Nginx::Request.new
+            r.set_uri_args(args)
+
+            Nginx.echo(r.args)
+          ';
+        }
+        location /get_post_args {
+          mruby_content_handler_code '
+            r = Nginx::Request.new
+            args = r.get_post_args
+
+            Nginx.echo args.map{|k, v| "#{k}:#{v}" }.join("\n")
+          ';
+        }
     }
     upstream mruby_upstream {
       server 127.0.0.1:80;

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -348,6 +348,21 @@ t.assert('ngx_mruby - fix bug issue 155', 'location /fix-bug-issue-155') do
   t.assert_equal ["abc=123", "foo=bar"], res['set-cookies']
 end
 
+t.assert('ngx_mruby - get_uri_args', 'location /get_uri_args') do
+  res = HttpRequest.new.get base + '/get_uri_args/?k=v'
+  t.assert_equal "k:v\n", res["body"]
+end
+
+t.assert('ngx_mruby - set_uri_args', 'location /set_uri_args') do
+  res = HttpRequest.new.get base + '/set_uri_args'
+  t.assert_equal "pass=ngx_mruby\n", res['body']
+end
+
+t.assert('ngx_mruby - get_post_args', 'location /get_post_args') do
+  res = HttpRequest.new.post base + '/get_post_args', 'foo=bar&bar=buzz'
+  t.assert_equal "foo:bar\nbar:buzz\n", res['body']
+end
+
 t.assert('ngx_mruby - ssl certificate changing') do
   res = `curl -k #{base_ssl + '/'}`
   t.assert_equal 'ssl test ok', res


### PR DESCRIPTION
I added `get_uri_args`, `set_uri_args` and `get_post_args`. We need to convert String to Hash using args parameter in Nginx::Request. This pull request makes to easy to use it.

These are stolen from ngx_lua :octocat: 