### PR TITLE
FIX: Add ln option "-n"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,7 @@ else
         echo "nginx Downloading ... Done"
         tar xf ${NGINX_SRC_VER}.tar.gz
     fi
-    ln -sf ${NGINX_SRC_VER} nginx_src
+    ln -snf ${NGINX_SRC_VER} nginx_src
     NGINX_SRC=`pwd`'/nginx_src'
     cd ..
 fi


### PR DESCRIPTION
In the case where you use `ln of GNU coreutils (ver. 8.22)`,
if you want to replace an existing directory symlink, you should add this option.

> This time, I wanted to overwrite other nginx version.

- GNU Manual says
```
  -n, --no-dereference
    treat LINK_NAME as a normal file if it is a symbolic link
to a directory
```

I checked `ln of FreeBSD 10.3`

- FreeBDS Manual say
```
-h	   If the target_file or target_dir is a symbolic link,	do not follow
	   it.	This is	most useful with the -f	option,	to replace a symlink
	   which may point to a	directory.

...

     -n	   Same	as -h, for compatibility with other ln implementations.
```

It seems that `each ln command` can use this option.
but I couldn't check `ln of other platform`.