### PR TITLE
Add rack.logger support.

### DIFF
--- a/mrbgems/rack-based-api/mrblib/rack.rb
+++ b/mrbgems/rack-based-api/mrblib/rack.rb
@@ -2,6 +2,46 @@ module Kernel
   module Rack
     Server = get_server_class
 
+    class Logger
+      def fatal(message = nil, &block)
+        add Server::LOG_EMERG, message, &block
+      end
+      def error(message = nil, &block)
+        add Server::LOG_ERR, message, &block
+      end
+      def warn(message = nil, &block)
+        add Server::LOG_WARN, message, &block
+      end
+      def info(message = nil, &block)
+        add Server::LOG_INFO, message, &block
+      end
+      def debug(message = nil, &block)
+        add Server::LOG_DEBUG, message, &block
+      end
+
+      # apache httpd/nginx specific 
+      def emerg(message = nil, &block)
+        add Server::LOG_EMERG, message, &block
+      end
+      def alert(message = nil, &block)
+        add Server::LOG_ALERT, message, &block
+      end
+      def crit(message = nil, &block) 
+        add Server::LOG_CRIT, message, &block
+      end
+      def notice(message = nil, &block) 
+        add Server::LOG_NOTICE, message, &block
+      end
+
+      private
+
+      def add(severity, message = nil)
+        message = yield if message.nil? && block_given?
+        Server.log severity, message
+      end
+
+    end
+
     def self.build_env r, c
       env = {}
       env = {
@@ -20,6 +60,7 @@ module Kernel
         "rack.multiprocess" => true,
         "rack.run_once"     => false,
         "rack.hijack?"      => false,
+        "rack.logger"       => Logger.new,
         "server.name"       => server_name,
         "server.version"    => Server.server_version,
       }

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -497,6 +497,34 @@ http {
             run p
           ';
         }
+        location /rack_base_logger {
+          mruby_content_handler_code '
+            p = Proc.new do |env|
+              logger = env["rack.logger"]
+              logger.fatal "Ignore me. This is for logger test"
+              logger.error "Ignore me. This is for logger test"
+              logger.warn "Ignore me. This is for logger test"
+              logger.info "Ignore me. This is for logger test"
+              logger.debug "Ignore me. This is for logger test"
+              logger.emerg "Ignore me. This is for logger test"
+              logger.alert "Ignore me. This is for logger test"
+              logger.crit "Ignore me. This is for logger test"
+              logger.notice "Ignore me. This is for logger test"
+
+              logger.fatal {"Ignore me." + " This is for logger with block test"}
+              logger.error {"Ignore me." + " This is for logger with block test"}
+              logger.warn {"Ignore me." + " This is for logger with block test"}
+              logger.info {"Ignore me." + " This is for logger with block test"}
+              logger.debug {"Ignore me." + " This is for logger with block test"}
+              logger.emerg {"Ignore me." + " This is for logger with block test"}
+              logger.alert {"Ignore me." + " This is for logger with block test"}
+              logger.crit {"Ignore me." + " This is for logger with block test"}
+              logger.notice {"Ignore me." + " This is for logger with block test"}
+              [200, {}, ["OK"]]
+            end
+            run p
+          ';
+        } 
         location /multi_headers_out {
           mruby_content_handler_code '
             r = Nginx::Request.new

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -327,6 +327,12 @@ t.assert('ngx_mruby - rack base push', 'location /rack_base_push/index.txt') do
   t.assert_equal "</index.js>; rel=preload", res["link"]
 end
 
+t.assert('ngx_mruby - rack base logger', 'location /rack_base_logger') do
+  res = HttpRequest.new.get base + '/rack_base_logger'
+  # just want to make sure if logger methods don't throw any exception.
+  t.assert_equal 200, res.code
+end
+
 t.assert('ngx_mruby - multipul request headers', 'location /multi_headers_in') do
   res = HttpRequest.new.get base + '/multi_headers_in', nil, {"hoge" => "foo"}
   t.assert_equal 200, res.code


### PR DESCRIPTION
The change requires mattn/mruby-json@f7f0ed91de172cdf9e4ad485b4a4cb29f0da542a to pass the test.