### PR TITLE
Fix master process memory leak when reloading nginx

### DIFF
--- a/src/stream/ngx_stream_mruby_module.c
+++ b/src/stream/ngx_stream_mruby_module.c
@@ -153,10 +153,20 @@ static mrb_state *ngx_stream_mrb_state_conf(ngx_conf_t *cf)
   return ((ngx_stream_mruby_main_conf_t *)ngx_stream_conf_get_module_main_conf(cf, ngx_stream_mruby_module))->ctx->mrb;
 }
 
+static void ngx_stream_mruby_cleanup(void *data)
+{
+  ngx_stream_mruby_main_conf_t *mmcf = data;
+
+  if (mmcf->ctx && mmcf->ctx->mrb) {
+    mrb_close(mmcf->ctx->mrb);
+  }
+}
+
 static void *ngx_stream_mruby_create_main_conf(ngx_conf_t *cf)
 {
   ngx_stream_mruby_main_conf_t *mmcf;
   ngx_stream_mruby_internal_ctx_t *ictx;
+  ngx_pool_cleanup_t *cln;
 
   mmcf = ngx_pcalloc(cf->pool, sizeof(ngx_stream_mruby_main_conf_t));
   if (mmcf == NULL) {
@@ -183,6 +193,14 @@ static void *ngx_stream_mruby_create_main_conf(ngx_conf_t *cf)
   ictx->s = NULL;
   ictx->stream_status = NGX_DECLINED;
   mmcf->ctx->mrb->ud = ictx;
+
+  cln = ngx_pool_cleanup_add(cf->pool, 0);
+  if (cln == NULL) {
+    return NULL;
+  }
+
+  cln->handler = ngx_stream_mruby_cleanup;
+  cln->data = mmcf;
 
   return mmcf;
 }


### PR DESCRIPTION
Thanks @hiboma and @hsbt for the report.

```
$ sudo cat /etc/nginx/nginx.conf
user  nginx;
daemon off;
worker_processes 1;

events { worker_connections 1024; }
http {}
```

```
sudo /usr/sbin/nginx 
```

```
$  while [ 1 ]; do sudo /usr/sbin/nginx -s reload; ps auxf | grep '[n]ginx: master'; sleep 1; done;
root      4147  0.0  0.9  54152  4792 pts/1    S+   14:34   0:00  |               \_ nginx: master process /usr/sbin/nginx
root      4147  0.0  1.0  54688  5332 pts/1    S+   14:34   0:00  |               \_ nginx: master process /usr/sbin/nginx
root      4147  0.0  1.1  55216  5856 pts/1    S+   14:34   0:00  |               \_ nginx: master process /usr/sbin/nginx
root      4147  0.2  1.2  55760  6376 pts/1    S+   14:34   0:00  |               \_ nginx: master process /usr/sbin/nginx
root      4147  0.1  1.3  56180  6864 pts/1    S+   14:34   0:00  |               \_ nginx: master process /usr/sbin/nginx
root      4147  0.1  1.4  56724  7364 pts/1    S+   14:34   0:00  |               \_ nginx: master process /usr/sbin/nginx
root      4147  0.1  1.5  57252  7836 pts/1    S+   14:34   0:00  |               \_ nginx: master process /usr/sbin/nginx
root      4147  0.1  1.6  57784  8504 pts/1    S+   14:34   0:00  |               \_ nginx: master process /usr/sbin/nginx
root      4147  0.3  1.7  58204  9008 pts/1    S+   14:34   0:00  |               \_ nginx: master process /usr/sbin/nginx
root      4147  0.2  1.8  58740  9496 pts/1    S+   14:34   0:00  |               \_ nginx: master process /usr/sbin/nginx
root      4147  0.2  1.9  59268  9948 pts/1    S+   14:34   0:00  |               \_ nginx: master process /usr/sbin/nginx
root      4147  0.2  2.0  59812 10404 pts/1    S+   14:34   0:00  |               \_ nginx: master process /usr/sbin/nginx
^C
```