### PR TITLE
Remove git-submodule process on build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,12 +41,6 @@ fi
 echo "NGINX_CONFIG_OPT=$NGINX_CONFIG_OPT"
 echo "NUM_THREADS=$NUM_THREADS"
 
-if [ ! -d "./mruby/src" ]; then
-    echo "mruby Downloading ..."
-    git submodule init
-    git submodule update
-    echo "mruby Downloading ... Done"
-fi
 cd mruby
 if [ -d "./${BUILD_DIR}" ]; then
     echo "mruby Cleaning ..."


### PR DESCRIPTION
ngx_mruby has used git-subtree instead of git-submodule.