### PR TITLE
Don't use git submodule command at build time.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -43,13 +43,6 @@ fi
 echo "NGINX_CONFIG_OPT=$NGINX_CONFIG_OPT"
 echo "NUM_THREADS=$NUM_THREADS"
 
-if [ ! -d "./mruby/src" ]; then
-    echo "mruby Downloading ..."
-    git submodule init
-    git submodule update
-    echo "mruby Downloading ... Done"
-fi
-
 if [ "$ONLY_BUILD_NGX_MRUBY" = "" ]; then
 
   echo "nginx Downloading ..."


### PR DESCRIPTION
Apply 453325ac3b760481eca5d7d849e6e1f89be4a0a5 to test.sh.