### PR TITLE
Support nginx bool value

### DIFF
--- a/src/http/ngx_http_mruby_core.c
+++ b/src/http/ngx_http_mruby_core.c
@@ -381,6 +381,9 @@ void ngx_mrb_core_class_init(mrb_state *mrb, struct RClass *class)
 {
   mrb_define_method(mrb, mrb->kernel_module, "server_name", ngx_mrb_server_name, MRB_ARGS_NONE());
 
+  mrb_define_const(mrb, class, "TRUE", mrb_str_new_lit(mrb, "1"));
+  mrb_define_const(mrb, class, "FALSE", mrb_str_new_lit(mrb, "0"));
+
   mrb_define_const(mrb, class, "OK", mrb_fixnum_value(NGX_OK));
   mrb_define_const(mrb, class, "ERROR", mrb_fixnum_value(NGX_ERROR));
   mrb_define_const(mrb, class, "AGAIN", mrb_fixnum_value(NGX_AGAIN));

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -633,6 +633,9 @@ http {
              f.body = (response + " world").upcase
           ';
         }
+        location /nginx_false_true {
+          mruby_content_handler_code 'Nginx.rputs (Nginx::FALSE + Nginx::TRUE)';
+        }
     }
     upstream mruby_upstream {
       server 127.0.0.1:80;

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -426,6 +426,11 @@ t.assert('ngx_mruby - issue_172_2', 'location /issue_172_2') do
   t.assert_equal expect_content.length, res["content-length"].to_i
 end
 
+t.assert('ngx_mruby - Nginx FALSE TRUE value', 'location /nginx_false_true') do
+  res = HttpRequest.new.get base + '/nginx_false_true/'
+  t.assert_equal "01", res["body"]
+end
+
 #
 # nginx stream test verison 1.9.6 later
 #


### PR DESCRIPTION
ref: http://buty4649.hatenablog.com/entry/2016/07/31/235836 [JA]

use like the following example:

```nginx
mruby_set_code $is_iphone '
  # do something
  Nginx::FALSE
';

if($is_iphone) {
  # process when $is_iphone is Nginx::TRUE
}
```