### PR TITLE
Implement mruby_ssl_handshake_handler()

### DIFF
--- a/mruby_test/build_config.rb
+++ b/mruby_test/build_config.rb
@@ -29,6 +29,7 @@ MRuby::Build.new do |conf|
   conf.gem :github => 'iij/mruby-io'
   conf.gem :github => 'iij/mruby-socket'
   conf.gem :github => 'iij/mruby-pack'
+  conf.gem :github => 'iij/mruby-env'
   # include the default GEMs
   conf.gembox 'full-core'
 

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -2525,6 +2525,9 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
   mrb->ud = mscf;
   ai = mrb_gc_arena_save(mrb);
   if (mscf->ssl_handshake_code != NGX_CONF_UNSET_PTR) {
+    if (!mscf->ssl_handshake_code->cache) {
+      NGX_MRUBY_STATE_REINIT_IF_NOT_CACHED(0, mscf->state, mscf->ssl_handshake_code, ngx_http_mruby_state_reinit_from_file);
+    }
     mrb_run(mrb, mscf->ssl_handshake_code->proc, mrb_top_self(mrb));
   }
   if (mscf->ssl_handshake_inline_code != NGX_CONF_UNSET_PTR) {

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -171,8 +171,8 @@ static ngx_command_t ngx_http_mruby_commands[] = {
 #if (NGX_HTTP_SSL)
 
     /* server config */
-    {ngx_string("mruby_ssl_handshake_handler"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE12,
-     ngx_http_mruby_ssl_handshake_phase, NGX_HTTP_SRV_CONF_OFFSET, 0, NULL},
+    {ngx_string("mruby_ssl_handshake_handler"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE12, ngx_http_mruby_ssl_handshake_phase,
+     NGX_HTTP_SRV_CONF_OFFSET, 0, NULL},
 
     {ngx_string("mruby_ssl_handshake_handler_code"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
      ngx_http_mruby_ssl_handshake_inline, NGX_HTTP_SRV_CONF_OFFSET, 0, NULL},
@@ -1060,7 +1060,7 @@ static char *ngx_http_mruby_ssl_handshake_phase(ngx_conf_t *cf, ngx_command_t *c
   code = ngx_http_mruby_mrb_code_from_file(cf->pool, &value[1]);
   if (code == NGX_CONF_UNSET_PTR) {
     ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, MODULE_NAME " : mruby_ssl_handshake_phase mrb_file(%s) open failed",
-            value[1].data);
+                       value[1].data);
     return NGX_CONF_ERROR;
   }
   if (cf->args->nelts == 3) {
@@ -1076,7 +1076,7 @@ static char *ngx_http_mruby_ssl_handshake_phase(ngx_conf_t *cf, ngx_command_t *c
   rc = ngx_http_mruby_shared_state_compile(cf, mscf->state, code);
   if (rc != NGX_OK) {
     ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, MODULE_NAME " : mruby_ssl_handshake_phase mrb_file(%s) open failed",
-            value[1].data);
+                       value[1].data);
     return NGX_CONF_ERROR;
   }
 
@@ -2526,7 +2526,8 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
   ai = mrb_gc_arena_save(mrb);
   if (mscf->ssl_handshake_code != NGX_CONF_UNSET_PTR) {
     if (!mscf->ssl_handshake_code->cache) {
-      NGX_MRUBY_STATE_REINIT_IF_NOT_CACHED(0, mscf->state, mscf->ssl_handshake_code, ngx_http_mruby_state_reinit_from_file);
+      NGX_MRUBY_STATE_REINIT_IF_NOT_CACHED(0, mscf->state, mscf->ssl_handshake_code,
+                                           ngx_http_mruby_state_reinit_from_file);
     }
     mrb_run(mrb, mscf->ssl_handshake_code->proc, mrb_top_self(mrb));
   }

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -2526,7 +2526,8 @@ static int ngx_http_mruby_ssl_cert_handler(ngx_ssl_conn_t *ssl_conn, void *data)
   ai = mrb_gc_arena_save(mrb);
   if (mscf->ssl_handshake_code != NGX_CONF_UNSET_PTR) {
     mrb_run(mrb, mscf->ssl_handshake_code->proc, mrb_top_self(mrb));
-  } else {
+  }
+  if (mscf->ssl_handshake_inline_code != NGX_CONF_UNSET_PTR) {
     mrb_run(mrb, mscf->ssl_handshake_inline_code->proc, mrb_top_self(mrb));
   }
 

--- a/src/http/ngx_http_mruby_module.c
+++ b/src/http/ngx_http_mruby_module.c
@@ -96,6 +96,7 @@ static char *ngx_http_mruby_init_worker_inline(ngx_conf_t *cf, ngx_command_t *cm
 static char *ngx_http_mruby_exit_worker_phase(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_http_mruby_exit_worker_inline(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 #if (NGX_HTTP_SSL)
+static char *ngx_http_mruby_ssl_handshake_phase(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static char *ngx_http_mruby_ssl_handshake_inline(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 #endif /* NGX_HTTP_SSL */
 
@@ -170,6 +171,9 @@ static ngx_command_t ngx_http_mruby_commands[] = {
 #if (NGX_HTTP_SSL)
 
     /* server config */
+    {ngx_string("mruby_ssl_handshake_handler"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE12,
+     ngx_http_mruby_ssl_handshake_phase, NGX_HTTP_SRV_CONF_OFFSET, 0, NULL},
+
     {ngx_string("mruby_ssl_handshake_handler_code"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
      ngx_http_mruby_ssl_handshake_inline, NGX_HTTP_SRV_CONF_OFFSET, 0, NULL},
 
@@ -1032,6 +1036,49 @@ static ngx_int_t ngx_http_mruby_shared_state_compile(ngx_conf_t *cf, ngx_mrb_sta
 */
 
 #if (NGX_HTTP_SSL)
+
+static char *ngx_http_mruby_ssl_handshake_phase(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+  ngx_http_mruby_srv_conf_t *mscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_mruby_module);
+  ngx_http_mruby_main_conf_t *mmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_mruby_module);
+  ngx_str_t *value;
+  ngx_mrb_code_t *code;
+  ngx_int_t rc;
+
+  if (mscf->ssl_handshake_code != NGX_CONF_UNSET_PTR) {
+    return "is duplicated";
+  }
+
+  /* share mrb_state of preinit */
+  mscf->state = mmcf->state;
+
+  value = cf->args->elts;
+
+  code = ngx_http_mruby_mrb_code_from_file(cf->pool, &value[1]);
+  if (code == NGX_CONF_UNSET_PTR) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, MODULE_NAME " : mruby_ssl_handshake_phase mrb_file(%s) open failed",
+            value[1].data);
+    return NGX_CONF_ERROR;
+  }
+  if (cf->args->nelts == 3) {
+    if (ngx_strcmp(value[2].data, "cache") == 0) {
+      code->cache = ON;
+    } else {
+      ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "invalid parameter \"%V\", vaild parameter is only \"cache\"",
+                         &value[2]);
+      return NGX_CONF_ERROR;
+    }
+  }
+  mscf->ssl_handshake_code = code;
+  rc = ngx_http_mruby_shared_state_compile(cf, mscf->state, code);
+  if (rc != NGX_OK) {
+    ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, MODULE_NAME " : mruby_ssl_handshake_phase mrb_file(%s) open failed",
+            value[1].data);
+    return NGX_CONF_ERROR;
+  }
+
+  return NGX_CONF_OK;
+}
 
 static char *ngx_http_mruby_ssl_handshake_inline(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 {

--- a/src/http/ngx_http_mruby_module.h
+++ b/src/http/ngx_http_mruby_module.h
@@ -56,6 +56,7 @@ extern ngx_module_t ngx_http_mruby_module;
 typedef struct {
   ngx_mrb_state_t *state;
   ngx_mrb_code_t *ssl_handshake_code;
+  ngx_mrb_code_t *ssl_handshake_inline_code;
   ngx_str_t *servername;
   ngx_str_t cert_path;
   ngx_str_t cert_key_path;

--- a/test.sh
+++ b/test.sh
@@ -114,6 +114,7 @@ if [ -n "$BUILD_DYNAMIC_MODULE" ]; then
 fi
 
 cp -pr test/html/* ${NGINX_INSTALL_DIR}/html/.
+sed -e "s|__NGXDOCROOT__|${NGINX_INSTALL_DIR}/html/|g" test/html/set_ssl_cert_and_key.rb > ${NGINX_INSTALL_DIR}/html/set_ssl_cert_and_key.rb
 
 echo "====================================="
 echo ""

--- a/test/build_config.rb
+++ b/test/build_config.rb
@@ -29,6 +29,7 @@ MRuby::Build.new do |conf|
   conf.gem :github => 'iij/mruby-io'
   conf.gem :github => 'iij/mruby-socket'
   conf.gem :github => 'iij/mruby-pack'
+  conf.gem :github => 'iij/mruby-env'
   # include the default GEMs
   conf.gembox 'full-core'
 

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -64,6 +64,21 @@ http {
     }
 
     server {
+        listen       58085 ssl;
+        server_name  _;
+        ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+        ssl_certificate     __NGXDOCROOT__/dummy.crt;
+        ssl_certificate_key __NGXDOCROOT__/dummy.key;
+
+        mruby_ssl_handshake_handler build/nginx/html/set_ssl_cert_and_key.rb cache;
+
+        location / {
+            mruby_content_handler_code "Nginx.rputs 'ssl test ok'";
+        }
+    }
+
+    server {
         listen       58081;
         server_name  localhost;
 

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -71,6 +71,21 @@ http {
         ssl_certificate     __NGXDOCROOT__/dummy.crt;
         ssl_certificate_key __NGXDOCROOT__/dummy.key;
 
+        mruby_ssl_handshake_handler build/nginx/html/set_ssl_cert_and_key.rb;
+
+        location / {
+            mruby_content_handler_code "Nginx.rputs 'ssl test ok'";
+        }
+    }
+
+    server {
+        listen       58086 ssl;
+        server_name  _;
+        ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+        ssl_certificate     __NGXDOCROOT__/dummy.crt;
+        ssl_certificate_key __NGXDOCROOT__/dummy.key;
+
         mruby_ssl_handshake_handler build/nginx/html/set_ssl_cert_and_key.rb cache;
 
         location / {

--- a/test/html/set_ssl_cert_and_key.rb
+++ b/test/html/set_ssl_cert_and_key.rb
@@ -1,0 +1,3 @@
+ssl = Nginx::SSL.new
+ssl.certificate = "__NGXDOCROOT__/#{ssl.servername}.crt"
+ssl.certificate_key = "__NGXDOCROOT__/#{ssl.servername}.key"

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -412,6 +412,15 @@ t.assert('ngx_mruby - ssl certificate changing using data instead of file') do
   t.assert_equal "", res
 end
 
+t.assert('ngx_mruby - ssl certificate changing - reading handler from file') do
+  res = `curl -k #{base_ssl(58085) + '/'}`
+  t.assert_equal 'ssl test ok', res
+  res = `openssl s_client -servername localhost -connect localhost:58083 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not | sed -e "s/://" | awk '{print (res = $6 - res)}' | tail -n 1`.chomp
+  t.assert_equal "1", res
+  res = `openssl s_client -servername hogehoge -connect 127.0.0.1:58083 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not`.chomp
+  t.assert_equal "", res
+end
+
 t.assert('ngx_mruby - issue_172', 'location /issue_172') do
   res = HttpRequest.new.get base + '/issue_172/index.html'
   expect_content = 'hello world'.upcase

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -415,18 +415,18 @@ end
 t.assert('ngx_mruby - ssl certificate changing - reading handler from file') do
   res = `curl -k #{base_ssl(58085) + '/'}`
   t.assert_equal 'ssl test ok', res
-  res = `openssl s_client -servername localhost -connect localhost:58083 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not | sed -e "s/://" | awk '{print (res = $6 - res)}' | tail -n 1`.chomp
+  res = `openssl s_client -servername localhost -connect localhost:58085 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not | sed -e "s/://" | awk '{print (res = $6 - res)}' | tail -n 1`.chomp
   t.assert_equal "1", res
-  res = `openssl s_client -servername hogehoge -connect 127.0.0.1:58083 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not`.chomp
+  res = `openssl s_client -servername hogehoge -connect 127.0.0.1:58085 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not`.chomp
   t.assert_equal "", res
 end
 
 t.assert('ngx_mruby - ssl certificate changing - reading handler from file with cache') do
   res = `curl -k #{base_ssl(58086) + '/'}`
   t.assert_equal 'ssl test ok', res
-  res = `openssl s_client -servername localhost -connect localhost:58083 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not | sed -e "s/://" | awk '{print (res = $6 - res)}' | tail -n 1`.chomp
+  res = `openssl s_client -servername localhost -connect localhost:58086 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not | sed -e "s/://" | awk '{print (res = $6 - res)}' | tail -n 1`.chomp
   t.assert_equal "1", res
-  res = `openssl s_client -servername hogehoge -connect 127.0.0.1:58083 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not`.chomp
+  res = `openssl s_client -servername hogehoge -connect 127.0.0.1:58086 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not`.chomp
   t.assert_equal "", res
 end
 

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -421,6 +421,15 @@ t.assert('ngx_mruby - ssl certificate changing - reading handler from file') do
   t.assert_equal "", res
 end
 
+t.assert('ngx_mruby - ssl certificate changing - reading handler from file with cache') do
+  res = `curl -k #{base_ssl(58086) + '/'}`
+  t.assert_equal 'ssl test ok', res
+  res = `openssl s_client -servername localhost -connect localhost:58083 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not | sed -e "s/://" | awk '{print (res = $6 - res)}' | tail -n 1`.chomp
+  t.assert_equal "1", res
+  res = `openssl s_client -servername hogehoge -connect 127.0.0.1:58083 < /dev/null 2> /dev/null | openssl x509 -text  | grep Not`.chomp
+  t.assert_equal "", res
+end
+
 t.assert('ngx_mruby - issue_172', 'location /issue_172') do
   res = HttpRequest.new.get base + '/issue_172/index.html'
   expect_content = 'hello world'.upcase


### PR DESCRIPTION
This function is equivalent to mruby_ssl_handshake_handler_code() #145, except that the file specified by ngx_mruby-script contains the mruby code to be executed.