### PR TITLE
Add CONTENT_TYPE and CONTENT_LENGTH to Rack environment

### DIFF
--- a/mrbgems/rack-based-api/mrblib/rack.rb
+++ b/mrbgems/rack-based-api/mrblib/rack.rb
@@ -81,8 +81,12 @@ module Kernel
       }
 
       # add rquest headers into env
-      r.headers_in.all.keys.each do |k|
-        env["HTTP_#{k.upcase.gsub('-', '_')}"] = r.headers_in[k]
+      r.headers_in.all.each do |k, v|
+        k = k.upcase.gsub('-', '_')
+        env["HTTP_#{k}"] = v 
+        # Rack spec doesn't allow env contains HTTP_CONTENT_TYPE or HTTP_CONTENT_LENGTH,
+        # but don't want to break backward compatibility.
+        env[k] = v if k == 'CONTENT_TYPE' || k == 'CONTENT_LENGTH'
       end
 
       env

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -314,6 +314,18 @@ t.assert('ngx_mruby - rack base', 'location /rack_base_env') do
   t.assert_equal 200, res.code
 end
 
+t.assert('ngx_mruby - rack base', 'method POST, location /rack_base_env') do
+  req_body = 'Hello' 
+  res = HttpRequest.new.post base + '/rack_base_env', req_body, {"Content-Type" => "text/plain; charset=us-ascii", "Content-Length" => req_body.size}
+  res_body = JSON.parse res["body"]
+  puts res_body
+
+  t.assert_equal "POST", res_body["REQUEST_METHOD"]
+  t.assert_equal "text/plain; charset=us-ascii", res_body["CONTENT_TYPE"]
+  t.assert_equal req_body.size.to_s, res_body["CONTENT_LENGTH"]
+  t.assert_equal 200, res.code
+end
+
 t.assert('ngx_mruby - rack base auth ok', 'location /rack_base_2phase') do
   res = HttpRequest.new.get base + '/rack_base_2phase', nil, {"auth-token" => "aaabbbccc"}
   t.assert_equal "OK", res["body"]


### PR DESCRIPTION
Add CONTENT_TYPE and CONTENT_LENGTH to Rack environment to comply with Rack spec.

The spec doesn't allow the env contains HTTP_CONTENT_TYPE or HTTP_CONTENT_LENGTH,
but I keep them for backward compatibilty.