### PR TITLE
Check response header type more strictly to avoid segmentation fault.

### DIFF
--- a/mrbgems/rack-based-api/mrblib/rack.rb
+++ b/mrbgems/rack-based-api/mrblib/rack.rb
@@ -96,11 +96,14 @@ module Kernel
       return if res.nil?
 
       if res[1].kind_of?(Hash)
-        res[1].keys.each { |k| r.headers_out[k] = res[1][k] }
+        res[1].each { |k, v| r.headers_out[k] = v }
       elsif res[1].kind_of?(Array)
-        res[1].each { |ary| r.headers_out[ary[0]] = ary[1] }
+        res[1].each { |ary| 
+          raise TypeError, "response headers arg type must be Array of Array or Hash" unless ary.kind_of?(Array)
+          r.headers_out[ary[0]] = ary[1] 
+        }
       else
-        raise TypeError, "response headers arg type must be Array or Hash"
+        raise TypeError, "response headers arg type must be Array of Array or Hash"
       end
       if res[2].kind_of?(Array)
         res[2].each { |b| Server.rputs b.to_s }

--- a/test/conf/nginx.conf
+++ b/test/conf/nginx.conf
@@ -505,6 +505,16 @@ http {
             run RackTest.new
           ';
         }
+        location /rack_base4 {
+          mruby_content_handler_code '
+            class RackTest
+              def call(env)
+                [200, [{"x-foo" => "foo"}], ["You never see this response"]]
+              end
+            end
+            run RackTest.new
+          ';
+        }
         location /rack_base_env {
           mruby_content_handler_code '
             class RackTest
@@ -666,7 +676,6 @@ http {
         location /nginx_false_true {
           mruby_content_handler_code 'Nginx.rputs (Nginx::FALSE + Nginx::TRUE)';
         }
-
     }
 
     server {

--- a/test/t/ngx_mruby.rb
+++ b/test/t/ngx_mruby.rb
@@ -286,6 +286,11 @@ t.assert('ngx_mruby - rack base', 'location /rack_base3') do
   t.assert_equal 404, res.code
 end
 
+t.assert('ngx_mruby - rack base', 'location /rack_base4') do
+  res = HttpRequest.new.get base + '/rack_base4'
+  t.assert_equal 500, res.code
+end
+
 t.assert('ngx_mruby - rack base', 'location /rack_base_env') do
   res = HttpRequest.new.get base + '/rack_base_env?a=1&b=1', nil, {"Host" => "ngx.example.com:58080", "x-hoge" => "foo"}
   body = JSON.parse res["body"]


### PR DESCRIPTION
ngx_mruby doesn't complain if Rack response headers is an Array of Hash, but it causes segmentation fault.


```
  location /foo {
    mruby_content_handler_code '
      class Foo
        def call(env)
          [200, [{"X-Foo" => "foo"}], ["body"]]
        end
      end
      run Foo.new
    ';
  }
```

```
Program received signal SIGSEGV, Segmentation fault.
ngx_mrb_set_request_header (mrb=mrb@entry=0x845190, headers=headers@entry=0xa709b0, pool=0xa70790, mrb_key=..., mrb_val=..., 
    update=update@entry=1) at /home/vagrant/mon/ngx_mruby/src/http/ngx_http_mruby_request.c:312
312	  key_len = (size_t)RSTRING_LEN(mrb_key);
Missing separate debuginfos, use: debuginfo-install glibc-2.17-106.el7_2.6.x86_64 libgcc-4.8.5-4.el7.x86_64 libstdc++-4.8.5-4.el7.x86_64 nss-softokn-freebl-3.16.2.3-13.el7_1.x86_64 openssl-libs-1.0.1e-51.el7_2.5.x86_64 pcre-8.32-15.el7_2.1.x86_64 zlib-1.2.7-15.el7.x86_64
(gdb) bt
#0  ngx_mrb_set_request_header (mrb=mrb@entry=0x845190, headers=headers@entry=0xa709b0, pool=0xa70790, mrb_key=..., 
    mrb_val=..., update=update@entry=1) at /home/vagrant/mon/ngx_mruby/src/http/ngx_http_mruby_request.c:312
#1  0x0000000000499aa4 in ngx_mrb_set_request_headers_out (mrb=0x845190, self=...)
    at /home/vagrant/mon/ngx_mruby/src/http/ngx_http_mruby_request.c:559
#2  0x00000000004c8806 in mrb_vm_exec (mrb=mrb@entry=0x845190, proc=<optimized out>, proc@entry=0x898f70, 
    pc=0x577f9c <gem_mrblib_irep_rack_based_api+3704>) at /home/vagrant/mon/ngx_mruby/mruby/src/vm.c:1150
#3  0x00000000004cdb4e in mrb_vm_run (stack_keep=<optimized out>, self=..., proc=0x898f70, mrb=0x845190)
    at /home/vagrant/mon/ngx_mruby/mruby/src/vm.c:759
#4  mrb_run (mrb=0x845190, proc=0x898f70, self=...) at /home/vagrant/mon/ngx_mruby/mruby/src/vm.c:2424
#5  0x0000000000493fed in ngx_mrb_run (r=0xa707e0, state=0x837950, code=0xa39508, cached=cached@entry=1, 
    result=result@entry=0x0) at /home/vagrant/mon/ngx_mruby/src/http/ngx_http_mruby_module.c:783
#6  0x00000000004945c4 in ngx_http_mruby_content_inline_handler (r=<optimized out>)
    at /home/vagrant/mon/ngx_mruby/src/http/ngx_http_mruby_module.c:1990
#7  0x000000000044cf1d in ngx_http_core_content_phase (r=0xa707e0, ph=0xa4e898) at src/http/ngx_http_core_module.c:1377
#8  0x0000000000447ca3 in ngx_http_core_run_phases (r=r@entry=0xa707e0) at src/http/ngx_http_core_module.c:847
#9  0x0000000000447dbc in ngx_http_handler (r=r@entry=0xa707e0) at src/http/ngx_http_core_module.c:830
#10 0x00000000004501cf in ngx_http_process_request (r=r@entry=0xa707e0) at src/http/ngx_http_request.c:1910
#11 0x0000000000452e03 in ngx_http_process_request_headers (rev=rev@entry=0xa745d0) at src/http/ngx_http_request.c:1342
#12 0x0000000000453118 in ngx_http_process_request_line (rev=rev@entry=0xa745d0) at src/http/ngx_http_request.c:1022
#13 0x0000000000453b53 in ngx_http_wait_request_handler (rev=0xa745d0) at src/http/ngx_http_request.c:499
#14 0x00000000004449bf in ngx_epoll_process_events (cycle=0x8339d0, timer=<optimized out>, flags=<optimized out>)
    at src/event/modules/ngx_epoll_module.c:822
#15 0x000000000043b3c2 in ngx_process_events_and_timers (cycle=cycle@entry=0x8339d0) at src/event/ngx_event.c:242
#16 0x0000000000443c44 in ngx_single_process_cycle (cycle=cycle@entry=0x8339d0) at src/os/unix/ngx_process_cycle.c:309
#17 0x000000000041fdf2 in main (argc=<optimized out>, argv=<optimized out>) at src/core/nginx.c:364
```